### PR TITLE
docs: expand guides and API reference for v2.0.0-beta.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ archive
 .ai/
 .github/copilot-instructions*.md
 LUME_2.0_FINAL_ROADMAP.md
+gh-pages-old
+references

--- a/README.md
+++ b/README.md
@@ -48,7 +48,16 @@ import { state, bindDom } from 'lume-js';
 ```
 
 ### Browser Support
-Works in all modern browsers (Chrome 49+, Firefox 18+, Safari 10+, Edge 79+). **IE11 is NOT supported.**
+
+| Browser | Minimum version |
+|---------|-----------------|
+| Chrome  | 49+             |
+| Firefox | 18+             |
+| Safari  | 10+             |
+| Edge    | 79+             |
+| IE11    | ❌ Not supported |
+
+IE11 cannot be polyfilled — Lume uses `Proxy`.
 
 ---
 
@@ -166,8 +175,6 @@ import { computed, watch, repeat } from 'lume-js/addons';
 - **`computed(fn)`** — Cached derived values with auto-tracking
 - **`watch(store, key, fn)`** — Subscribe to state changes
 - **`repeat(container, store, key, options)`** — Keyed list rendering with element reuse
-
-> **Note:** The `repeat` addon is *experimental*. Its API may evolve in future releases.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,63 +1,150 @@
-# Introduction
+# Lume.js Documentation
 
-**Lume.js** is a minimal reactive state management library using only standard JavaScript and HTML. No custom syntax, no build step required, no framework lock-in.
+**Lume.js** is a lightweight reactive state library built on standard JavaScript and HTML. Drop it into any page via a CDN `<script>` tag and get reactive bindings in minutes — no build tool, no custom syntax, no framework required.
 
-> **Current Version:** 2.0.0-beta.1 | Core: 2.39KB gzipped | 231 tests
+> **Version:** 2.0.0-beta.1 · **Core:** ~2.4 KB gzipped · **Tests:** 231 · **Dependencies:** 0
 
 ## Why Lume.js?
 
-- **Standards-Only**: Uses `data-*` attributes and standard JS.
-- **Tiny**: ~2.4KB gzipped core, zero dependencies.
-- **No Virtual DOM**: Direct DOM manipulation for maximum performance.
-- **Extensible**: Composable handler system for reactive attributes.
-- **Tree-shakeable**: Import only what you need (`lume-js/handlers`, `lume-js/addons`).
+| | Lume.js | Vue / React / Svelte |
+|--|---------|----------------------|
+| Build step | None required | Required |
+| Custom syntax | None — plain `data-*` attrs | Templates / JSX / `.svelte` |
+| Bundle size | ~2.4 KB gzipped | 40 KB+ |
+| Learning curve | ~15 min | Days |
+| Virtual DOM | No — direct DOM | Yes |
 
-## Quick Start
+Lume is a good fit when you want reactive state without a full framework: dashboards, interactive documentation, progressive enhancement on server-rendered pages, and small single-page apps.
 
-### 1. Install
+## Quick start
 
-**Via CDN:**
+### CDN — no install needed
+
+Paste this into an HTML file and open it in a browser. No npm, no bundler, no config.
+
 ```html
-<script type="module">
-  import { state, bindDom } from 'https://cdn.jsdelivr.net/npm/lume-js/src/index.js';
-</script>
+<!DOCTYPE html>
+<html>
+<body>
+  <h1>Hello, <span data-bind="name"></span>!</h1>
+  <input data-bind="name" placeholder="Your name">
+
+  <script type="module">
+    import { state, bindDom } from 'https://cdn.jsdelivr.net/npm/lume-js/src/index.js';
+
+    const store = state({ name: 'World' });
+    bindDom(document.body, store);
+  </script>
+</body>
+</html>
 ```
 
-**Via NPM:**
+### npm
+
 ```bash
 npm install lume-js
 ```
 
-### 2. Create State & Bind
+```js
+import { state, bindDom, effect } from 'lume-js';
+import { watch, computed } from 'lume-js/addons';
+import { show, classToggle, stringAttr } from 'lume-js/handlers';
+```
 
-**HTML:**
+## The three ideas
+
+The entire library is built on three primitives. Once you understand them, you understand Lume.
+
+### 1. `state(obj)` — reactive store
+
+```js
+const store = state({ count: 0 });
+
+store.count = 1;  // any subscribers are notified automatically
+```
+
+### 2. `bindDom(root, store)` — DOM bindings
+
+Scans for `data-*` attributes and wires them to the store. Form controls get two-way binding; everything else gets one-way (`textContent`).
+
 ```html
-<div>
-  <h1>Hello, <span data-bind="name"></span>!</h1>
-  <input data-bind="name" placeholder="Enter your name">
-</div>
+<span data-bind="count"></span>       <!-- textContent = store.count -->
+<input data-bind="name">               <!-- value ⇄ store.name (two-way) -->
+<input type="checkbox" data-bind="on"> <!-- checked ⇄ boolean -->
+<select data-bind="theme">…</select>   <!-- value ⇄ store.theme -->
 ```
 
-**JavaScript:**
-```javascript
-import { state, bindDom } from 'lume-js';
+### 3. `effect(fn)` — reactive side-effects
 
-const store = state({ name: 'World' });
-bindDom(document.body, store);
-```
+Runs a function immediately and re-runs it whenever the store data it read changes. Dependencies are tracked automatically — no explicit list needed.
 
-### 3. Extend with Handlers (optional)
+```js
+import { effect } from 'lume-js';
 
-```javascript
-import { show, classToggle } from 'lume-js/handlers';
-
-bindDom(document.body, store, {
-  handlers: [show, classToggle('active')]
+effect(() => {
+  document.title = `${store.count} items`;  // re-runs when count changes
 });
 ```
 
-## Next Steps
+Need more control? `lume-js/addons` includes `watch` (subscribe to a single key) and `computed` (cached derived value):
 
-- Follow the [Build a Todo App](tutorials/build-todo-app.md) tutorial.
-- Learn about [Reactivity](api/core/state.md).
-- Explore [Guides](guides/README.md) for advanced topics.
+```js
+import { watch, computed } from 'lume-js/addons';
+
+watch(store, 'theme', (theme) => {
+  localStorage.setItem('theme', theme);      // fires only when theme changes
+});
+
+const total = computed(() => store.items.reduce((s, i) => s + i.price, 0));
+console.log(total.value);  // cached until items changes
+```
+
+## Package exports
+
+| Import | Contents |
+|--------|----------|
+| `lume-js` | `state`, `isReactive`, `bindDom`, `effect` |
+| `lume-js/addons` | `watch`, `computed`, `repeat`, `createDebugPlugin`, `debug`, `defaultFocusPreservation`, `defaultScrollPreservation` |
+| `lume-js/handlers` | `show`, `boolAttr`, `ariaAttr`, `classToggle`, `stringAttr`, `formHandlers`, `a11yHandlers`, `htmlAttrs` |
+
+## Documentation
+
+### Getting started
+- [Installation](guides/installation.md)
+- [Quick start](guides/quick-start.md)
+- [Core concepts](guides/core-concepts.md)
+
+### Guides
+- [How reactivity works](guides/reactivity.md)
+- [Handlers](guides/handlers.md)
+- [Two-way binding](guides/two-way-binding.md)
+- [Lists & repeat](guides/lists.md)
+- [Performance](guides/performance.md)
+
+### API — Core
+- [state()](api/core/state.md)
+- [bindDom()](api/core/bindDom.md)
+- [effect()](api/core/effect.md)
+
+### API — Addons
+- [watch()](api/addons/watch.md)
+- [computed()](api/addons/computed.md)
+- [repeat()](api/addons/repeat.md)
+
+### API — Handlers
+- [show](api/handlers/show.md)
+- [classToggle](api/handlers/classToggle.md)
+- [stringAttr](api/handlers/stringAttr.md)
+
+### Tutorials
+- [Build a Todo app](tutorials/build-todo-app.md)
+- [Build Tic-Tac-Toe](tutorials/build-tic-tac-toe.md)
+
+### Reference
+- [FAQ](guides/faq.md)
+- [Migrating from 1.x](guides/migration.md)
+- [Changelog](../CHANGELOG.md)
+
+---
+
+**Next: [Installation](guides/installation.md) →**

--- a/docs/api/addons/computed.md
+++ b/docs/api/addons/computed.md
@@ -1,53 +1,95 @@
-# computed(getter)
+# computed(fn)
 
-Creates a read-only reactive value that automatically updates when its dependencies change.
+Creates a cached, read-only reactive value derived from store state.
 
 ## Signature
 
-```typescript
-function computed<T>(getter: () => T): {
-  value: T;
-  subscribe: (callback: (val: T) => void) => () => void;
-  dispose: () => void;
-};
+```ts
+function computed<T>(fn: () => T): {
+  readonly value: T;
+  subscribe(callback: (value: T) => void): () => void;
+  dispose(): void;
+}
 ```
+
+Imported from `lume-js/addons`.
 
 ## Parameters
 
-- `getter` (Function): A function that returns the computed value.
+- `fn` — A getter function. Must be synchronous. Should have no side effects.
 
 ## Returns
 
 An object with:
-- `value` (Getter): The current computed value.
-- `subscribe(callback)`: Subscribes to changes.
-- `dispose()`: Stops the computation and frees memory.
+- `value` — The current computed result. Re-evaluated only when dependencies change.
+- `subscribe(callback)` — Subscribes to value changes. Calls `callback` immediately with the current value, then again on every subsequent change. Returns an unsubscribe function.
+- `dispose()` — Stops the computation and frees subscriptions.
 
 ## Description
 
-`computed` values are cached. They only re-evaluate when their dependencies change.
+`computed` uses the same auto-tracking as `effect`: all store reads inside `fn` become dependencies. When any dependency changes, `fn` re-runs on the next microtask flush. The result is cached — `fn` never runs more than once per dependency change, no matter how many places read `computed.value`.
 
-## Example
-
-```javascript
+```js
 import { state } from 'lume-js';
 import { computed } from 'lume-js/addons';
 
-const store = state({
-  price: 10,
-  quantity: 2
+const store = state({ price: 1.5, qty: 2 });
+
+const total = computed(() => store.price * store.qty);
+
+console.log(total.value); // 3
+
+store.qty = 4;
+// After microtask:
+console.log(total.value); // 6
+```
+
+## Filtering lists
+
+```js
+const store = state({ todos: [...], filter: 'all' });
+
+const visible = computed(() => {
+  if (store.filter === 'active')    return store.todos.filter(t => !t.done);
+  if (store.filter === 'completed') return store.todos.filter(t => t.done);
+  return store.todos;
 });
 
-const total = computed(() => store.price * store.quantity);
-
-console.log(total.value); // 20
-
-store.price = 20;
-// total.value is now 40
+// Use in effects or templates:
+effect(() => {
+  badge.textContent = visible.value.length;
+});
 ```
+
+## With `repeat`
+
+Pass a computed as the store to `repeat`, with `'value'` as the key:
+
+```js
+import { repeat } from 'lume-js/addons';
+
+repeat(listEl, visible, 'value', {
+  key: todo => todo.id,
+  render: (todo, el) => { el.textContent = todo.text; }
+});
+```
+
+## Cleanup
+
+`computed` creates an internal `effect`. Call `dispose()` when the computed is no longer needed:
+
+```js
+const c = computed(() => store.x * 2);
+// … later
+c.dispose();
+```
+
+## See also
+
+- [effect()](../core/effect.md)
+- [watch()](watch.md)
+- [Lists & repeat](../../guides/lists.md)
 
 ---
 
-**← Previous: [effect()](../core/effect.md)** | **Next: [repeat()](repeat.md) →**
-
-> **Deep Dive:** Why is `computed` an addon? Read the [Design Decision](../../design/design-decisions.md#why-no-computed-properties-in-core).
+**← Previous: [watch()](watch.md)** | **Next: [repeat()](repeat.md) →**

--- a/docs/api/addons/debug.md
+++ b/docs/api/addons/debug.md
@@ -1,6 +1,6 @@
 # createDebugPlugin(options)
 
-Developer-friendly logging and inspection of reactive state operations.
+`createDebugPlugin` logs every read, write, and notification on a store to the console. Use it during development to see exactly which state changes triggered which updates — and which keys are being read more than you expect.
 
 ## Import
 
@@ -10,7 +10,7 @@ import { createDebugPlugin, debug } from 'lume-js/addons';
 
 ## createDebugPlugin(options)
 
-Creates a debug plugin instance for a reactive state store.
+Creates a debug plugin for a store. Pass it in the `plugins` array when calling `state()`.
 
 ### Signature
 
@@ -67,7 +67,7 @@ config.logGet = true;  // Now GET operations will log
 
 ## debug (Global Controls)
 
-Global debug object for controlling all debug plugins.
+`debug` is a global object that controls all active debug plugins at once. Use it to toggle logging, filter by key name, or inspect operation counts without touching each store individually.
 
 ### Methods
 
@@ -129,4 +129,3 @@ Debug logs use colored output:
 
 **← Previous: [watch()](watch.md)** | **Next: [Guides](../../guides/README.md) →**
 
-> **Demo:** See the [Debug Demo](/examples/debug-demo/) for interactive usage.

--- a/docs/api/addons/repeat.md
+++ b/docs/api/addons/repeat.md
@@ -1,95 +1,143 @@
 # repeat(container, store, key, options)
 
-Efficiently renders a list of items based on an array in the state.
+The right tool for any list that changes. `repeat` renders a keyed list from a reactive array and reuses existing DOM nodes across updates — so adding, removing, or reordering items only touches what actually changed.
 
 ## Signature
 
-```typescript
+```ts
 function repeat(
   container: HTMLElement | string,
   store: object,
   key: string,
   options: {
-    key: (item: any) => any;
+    key: (item: any) => string | number;
     render?: (item: any, el: HTMLElement, index: number) => void;
     create?: (item: any, el: HTMLElement, index: number) => void;
-    update?: (item: any, el: HTMLElement, index: number, context: { isFirstRender: boolean }) => void;
+    update?: (item: any, el: HTMLElement, index: number, ctx: { isFirstRender: boolean }) => void;
     element?: string | (() => HTMLElement);
+    preserveFocus?: Function | null;
+    preserveScroll?: Function | null;
   }
-): () => void;
+): () => void
 ```
+
+Imported from `lume-js/addons`.
 
 ## Parameters
 
-- `container`: The DOM element (or selector string) to render into.
-- `store`: The reactive state object.
-- `key`: The property name of the array in the state.
-- `options`:
-    - `key` (Function): Returns a unique ID for each item. **Critical for performance.**
-    - `render` (Function, optional): Called for all items (both new and existing). Use for simple cases.
-    - `create` (Function, optional): Called once when a new element is created (for DOM structure).
-    - `update` (Function, optional): `(item, el, index, { isFirstRender }) => void`. Called for data binding. Skipped if same object reference AND same index.
-    - `element` (String or Function, optional): The HTML tag or factory (default: `div`).
+- `container` — The element (or CSS selector string) to render into.
+- `store` — A reactive store or computed whose key holds the array.
+- `key` — The property name of the array in `store`.
+- `options.key` — **Required.** Returns a stable unique identifier per item. Used to match DOM nodes across updates.
+- `options.render` — Mutates the element directly. (Return value is ignored). Called for new and updated items.
+- `options.create` — Called once when a new DOM element is created. Use for DOM structure and event listeners.
+- `options.update` — Called for data binding. Receives `{ isFirstRender }` so you can animate only on updates. **Skipped when the item reference and index are both unchanged from the previous render** (optimization). Use `render` instead if you always need to re-apply data regardless of reference equality.
+- `options.element` — Tag name or factory for the wrapper element. Default: `'div'`.
+- `options.preserveFocus` — Optional strategy for preserving focus during re-renders. Default: `defaultFocusPreservation`.
+- `options.preserveScroll` — Optional strategy for preserving scroll position during re-renders. Default: `defaultScrollPreservation`.
+
+Use `render` alone for simple read-only lists. Use `create + update` for lists with event listeners — `create` runs once when the element is created, `update` runs on every data change.
 
 ## Returns
 
-- A cleanup function.
+A cleanup function.
 
-## Description
+## Pattern 1 — Simple (render only)
 
-`repeat` synchronizes a DOM list with an array in your state. It uses the `key` function to track item identity, ensuring that DOM elements are reused, reordered, or removed efficiently rather than re-rendered from scratch.
+Best for read-only lists where no event listeners are needed on items.
 
-**Important:** You must use **immutable updates** for the array (e.g., `store.items = [...newItems]`) for `repeat` to detect changes.
-
-## Pattern 1: Simple (render only)
-
-Best for simple items where you don't need DOM/data separation.
-
-```javascript
+```js
 import { state } from 'lume-js';
 import { repeat } from 'lume-js/addons';
 
-const store = state({ users: [{ id: 1, name: 'Alice' }] });
+const store = state({
+  todos: [
+    { id: 1, text: 'Buy milk', done: false },
+    { id: 2, text: 'Walk dog', done: true  },
+  ]
+});
 
-repeat('#user-list', store, 'users', {
-  key: user => user.id,
-  render: (user, el) => {
-    el.textContent = user.name;  // Called on every update
+repeat(document.getElementById('list'), store, 'todos', {
+  key: todo => todo.id,
+  element: 'li',
+  render: (todo, el) => {
+    el.className = todo.done ? 'done' : '';
+    el.textContent = todo.text;
   }
 });
 ```
 
-## Pattern 2: Clean API (create + update) — Recommended
+## Pattern 2 — create + update (recommended)
 
-Best for complex items with event listeners and DOM structure.
+Best for items with event listeners. `create` runs once per DOM element; `update` runs on every data change.
 
-```javascript
-repeat('#user-list', store, 'users', {
-  key: user => user.id,
-  create: (user, el) => {
-    // Called ONCE - create DOM structure and attach listeners
-    el.innerHTML = '<span class="name"></span><button>Delete</button>';
-    el.querySelector('button').onclick = () => deleteUser(user.id);
+```js
+repeat('#todo-list', store, 'todos', {
+  key: todo => todo.id,
+  element: 'li',
+
+  create: (todo, el) => {
+    el.innerHTML = `
+      <input type="checkbox" class="toggle">
+      <span class="text"></span>
+      <button class="delete">×</button>
+    `;
+    el.querySelector('.toggle').onchange = () => {
+      store.todos = store.todos.map(t =>
+        t.id === todo.id ? { ...t, done: !t.done } : t
+      );
+    };
+    el.querySelector('.delete').onclick = () => {
+      store.todos = store.todos.filter(t => t.id !== todo.id);
+    };
   },
-  update: (user, el, index, { isFirstRender }) => {
-    // Called on each render - bind data
-    // isFirstRender = true on initial, false on subsequent
-    el.querySelector('.name').textContent = user.name;
-    
-    if (!isFirstRender) {
-      el.classList.add('updated');  // Animate only on updates
-    }
+
+  update: (todo, el, index, { isFirstRender }) => {
+    el.querySelector('.toggle').checked = todo.done;
+    el.querySelector('.text').textContent = todo.text;
+    el.classList.toggle('done', todo.done);
+    if (!isFirstRender) el.classList.add('updated'); // animate on change
   }
 });
 ```
 
-## Performance
+## Array operations
 
-- **Reference optimization**: `update` is skipped if the item object reference hasn't changed
-- **Keyed diffing**: Elements are reused by key, not recreated
-- **Minimal DOM operations**: Only changed elements are touched
+| Array change | DOM effect |
+|--------------|------------|
+| New key added (immutable replace) | Appends/inserts new row |
+| Key removed (immutable replace) | Removes row |
+| Reorder — same keys (immutable replace) | Moves existing nodes, `update` fires (index changed) |
+| Same key, item ref changed | Only that row's `update` fires |
+
+## Using with `computed`
+
+Pass a `computed` as the store and `'value'` as the key:
+
+```js
+import { computed } from 'lume-js/addons';
+
+const filtered = computed(() =>
+  store.todos.filter(t => store.filter === 'all' || !t.done)
+);
+
+repeat(listEl, filtered, 'value', {
+  key: t => t.id,
+  render: (t, el) => { el.textContent = t.text; }
+});
+```
+
+## Caveats
+
+- **Keys must be unique.** Duplicate keys log a warning; both items end up sharing the same DOM element, which produces incorrect rendering.
+- **Each rendered element must have exactly one root.** Wrap fragments in a `<div>` or `<li>`.
+
+## See also
+
+- [Lists & repeat guide](../../guides/lists.md)
+- [computed()](computed.md)
+- [Todo app tutorial](../../tutorials/build-todo-app.md)
 
 ---
 
-**← Previous: [computed()](computed.md)** | **Next: [Guides](../../guides/forms.md) →**
-
+**← Previous: [computed()](computed.md)** | **Next: [show](../handlers/show.md) →**

--- a/docs/api/addons/watch.md
+++ b/docs/api/addons/watch.md
@@ -1,40 +1,86 @@
-# watch(store, key, callback)
+# watch(store, key, fn)
 
-Watches a specific property on a state object for changes.
+Subscribes to a single store key. More explicit than `effect` — no auto-tracking, and the callback always receives the new value directly.
 
 ## Signature
 
-```typescript
+```ts
 function watch(
-  store: object, 
-  key: string, 
-  callback: (value: any) => void
-): () => void;
+  store: object,
+  key: string,
+  fn: (newValue: any) => void
+): () => void
 ```
+
+Imported from `lume-js/addons`.
 
 ## Parameters
 
-- `store` (Object): The reactive state object.
-- `key` (String): The property name to watch.
-- `callback` (Function): Called with the new value.
+- `store` — A reactive store created by `state()`.
+- `key` — The property name to watch.
+- `fn` — Called with `(newValue)` immediately on subscribe, then on every subsequent change.
 
 ## Returns
 
-- An unsubscribe function.
+An unsubscribe function. Call it to stop watching.
 
-## Description
+## Examples
 
-`watch` is a convenience alias for `store.$subscribe(key, callback)`.
+### Basic
 
-## Example
-
-```javascript
+```js
 import { state } from 'lume-js';
 import { watch } from 'lume-js/addons';
 
-const store = state({ count: 0 });
+const store = state({ theme: 'light', count: 0 });
 
-watch(store, 'count', (val) => {
-  console.log('Count is now:', val);
+watch(store, 'theme', (newTheme) => {
+  document.documentElement.dataset.theme = newTheme;
+});
+// Called immediately with 'light', then again on every change
+
+store.theme = 'dark'; // callback fires with 'dark'
+```
+
+### One-time watcher
+
+```js
+const stop = watch(store, 'count', (val) => {
+  if (val >= 10) {
+    console.log('Reached 10!');
+    stop(); // unsubscribe after the condition is met
+  }
 });
 ```
+
+### Side effects (localStorage, analytics)
+
+`watch` is the right tool for side effects that should react to exactly one key. Unlike auto-tracking `effect`, there is no risk of accidentally subscribing to extra keys.
+
+```js
+watch(store, 'theme', (theme) => {
+  localStorage.setItem('theme', theme);
+});
+
+watch(store, 'userId', (id) => {
+  analytics.identify(id);
+});
+```
+
+## Compared to `effect`
+
+| | `effect(fn)` | `watch(store, key, fn)` |
+|--|--------------|------------------------|
+| Dependency tracking | Auto — all reads inside fn | Explicit — one key only |
+| Callback args | none | `(newValue)` |
+| Runs immediately | Yes (on first call) | Yes (always, on subscribe) |
+| Best for | UI bindings, rendering | Side effects, persistence |
+
+## See also
+
+- [effect()](../core/effect.md)
+- [computed()](computed.md)
+
+---
+
+**← Previous: [effect()](../core/effect.md)** | **Next: [computed()](computed.md) →**

--- a/docs/api/core/bindDom.md
+++ b/docs/api/core/bindDom.md
@@ -1,70 +1,62 @@
 # bindDom(root, store, options?)
 
-Binds a reactive state to DOM elements using `data-*` attributes.
+Scans a DOM subtree for `data-*` attributes and wires them reactively to a store.
 
 ## Signature
 
-```typescript
+```ts
 function bindDom(
-  root: HTMLElement, 
-  store: ReactiveState<any>, 
-  options?: BindDomOptions
-): () => void;
-
-interface BindDomOptions {
-  immediate?: boolean;
-  handlers?: (Handler | Handler[])[];
-}
-
-interface Handler {
-  readonly attr: string;
-  apply(el: HTMLElement, val: any): void;
-}
+  root: HTMLElement,
+  store: object,
+  options?: {
+    immediate?: boolean;
+    handlers?: Handler[];
+  }
+): () => void
 ```
 
 ## Parameters
 
-- `root` (HTMLElement): The root element to scan for bindings.
-- `store` (Object): The reactive state object created by `state()`.
-- `options` (Object, optional):
-    - `immediate` (Boolean): If `true`, binds immediately without waiting for `DOMContentLoaded`. Default is `false`.
-    - `handlers` (Array): Additional handlers for reactive `data-*` attributes. See [Handlers](handlers.md).
+- `root` — The root element to scan. All descendants are included.
+- `store` — A reactive store created by `state()`.
+- `options.immediate` — If `true`, binds immediately instead of waiting for `DOMContentLoaded`.
+- `options.handlers` — Additional handler objects. See [Handlers](../../guides/handlers.md).
 
 ## Returns
 
-- A cleanup function that removes all bindings and event listeners.
+A cleanup function. Call it to remove all bindings and event listeners created by this call.
 
-## Description
+## Built-in bindings
 
-Scans the `root` element for elements with reactive `data-*` attributes. It sets up:
-1.  **Two-way binding** (`data-bind`): Updates DOM when state changes, updates state when form inputs change.
-2.  **Boolean attributes** (`data-hidden`, `data-disabled`, `data-checked`, `data-required`): Toggles DOM properties.
-3.  **ARIA attributes** (`data-aria-expanded`, `data-aria-hidden`): Sets "true"/"false" string values.
-4.  **Custom handlers**: Any additional handlers passed via `options.handlers`.
+### `data-bind` — two-way for forms, one-way for everything else
 
-## Built-in Attributes
+| Element | Property | Event |
+|---------|----------|-------|
+| `<input type="text">` and friends | `value` | `input` |
+| `<input type="checkbox">` | `checked` | `input` |
+| `<input type="radio">` | `checked` (by value) | `input` |
+| `<input type="number">` | `valueAsNumber` | `input` |
+| `<input type="range">` | `valueAsNumber` | `input` |
+| `<input type="date">` | `value` | `input` |
+| `<textarea>` | `value` | `input` |
+| `<select>` | `value` | `input` |
+| Anything else | `textContent` | — (one-way) |
 
-| Attribute | Effect | Example |
-| :--- | :--- | :--- |
-| `data-bind="key"` | Two-way binding for inputs, `textContent` for others | `<input data-bind="name">` |
-| `data-hidden="key"` | `el.hidden = Boolean(val)` | `<div data-hidden="isLoading">` |
-| `data-disabled="key"` | `el.disabled = Boolean(val)` | `<button data-disabled="isSubmitting">` |
-| `data-checked="key"` | `el.checked = Boolean(val)` | `<input data-checked="isAgreed" type="checkbox">` |
-| `data-required="key"` | `el.required = Boolean(val)` | `<input data-required="fieldRequired">` |
-| `data-aria-expanded="key"` | `el.setAttribute('aria-expanded', 'true'/'false')` | `<button data-aria-expanded="menuOpen">` |
-| `data-aria-hidden="key"` | `el.setAttribute('aria-hidden', 'true'/'false')` | `<div data-aria-hidden="isCollapsed">` |
+### Boolean attributes
 
-## Supported Elements for `data-bind`
+| Attribute | Effect |
+|-----------|--------|
+| `data-hidden="key"` | `el.hidden = Boolean(val)` |
+| `data-disabled="key"` | `el.disabled = Boolean(val)` |
+| `data-checked="key"` | `el.checked = Boolean(val)` |
+| `data-required="key"` | `el.required = Boolean(val)` |
 
-| Element | Attribute Updated | Event Listened |
-| :--- | :--- | :--- |
-| `input[type="text"]` | `value` | `input` |
-| `input[type="checkbox"]` | `checked` | `input` |
-| `input[type="radio"]` | `checked` | `input` |
-| `input[type="number/range"]` | `valueAsNumber` | `input` |
-| `select` | `value` | `input` |
-| `textarea` | `value` | `input` |
-| Other (div, span, etc.) | `textContent` | — |
+### ARIA attributes
+
+| Attribute | Effect |
+|-----------|--------|
+| `data-aria-expanded="key"` | `el.setAttribute('aria-expanded', 'true'/'false')` |
+| `data-aria-hidden="key"` | `el.setAttribute('aria-hidden', 'true'/'false')` |
 
 ## Examples
 
@@ -73,51 +65,25 @@ Scans the `root` element for elements with reactive `data-*` attributes. It sets
 ```html
 <div id="app">
   <h1 data-bind="title"></h1>
-  <input data-bind="title">
+  <input data-bind="title" placeholder="Title">
+  <button data-disabled="saving">Save</button>
 </div>
-
-<script type="module">
-  import { state, bindDom } from 'lume-js';
-
-  const store = state({ title: 'Hello' });
-  const cleanup = bindDom(document.getElementById('app'), store);
-</script>
 ```
 
-### With Built-in Attributes
+```js
+import { state, bindDom } from 'lume-js';
 
-```html
-<form id="signup">
-  <input data-bind="email" data-required="emailRequired">
-  <button data-disabled="isSubmitting">Submit</button>
-  <div data-hidden="isSuccess">Thanks!</div>
-</form>
-
-<script type="module">
-  import { state, bindDom } from 'lume-js';
-
-  const store = state({
-    email: '',
-    emailRequired: true,
-    isSubmitting: false,
-    isSuccess: false
-  });
-
-  bindDom(document.getElementById('signup'), store);
-</script>
+const store = state({ title: 'Hello', saving: false });
+const cleanup = bindDom(document.getElementById('app'), store);
 ```
 
-### With Handlers
+### With handlers
 
-```javascript
+```js
 import { state, bindDom } from 'lume-js';
 import { show, classToggle, stringAttr } from 'lume-js/handlers';
 
-const store = state({
-  isVisible: true,
-  isActive: false,
-  profileUrl: '/user/alice'
-});
+const store = state({ visible: true, active: false, url: '/profile' });
 
 bindDom(document.body, store, {
   handlers: [show, classToggle('active'), stringAttr('href')]
@@ -125,51 +91,31 @@ bindDom(document.body, store, {
 ```
 
 ```html
-<span data-show="isVisible">Content</span>
-<div data-class-active="isActive">Item</div>
-<a data-href="profileUrl">Profile</a>
+<div data-show="visible">Content</div>
+<li data-class-active="active">Item</li>
+<a data-href="url">Profile</a>
 ```
 
-### Nested State Paths
+### Cleanup
 
-```javascript
-const store = state({
-  user: state({ name: 'Alice', isAdmin: false })
-});
+```js
+const cleanup = bindDom(root, store);
 
-bindDom(document.body, store);
+// Later — removes all bindings
+cleanup();
 ```
 
-```html
-<span data-bind="user.name"></span>
-<div data-hidden="user.isAdmin">Admin Panel</div>
-```
+## Performance notes
 
-## Performance
+- Uses a single event listener at `root` (event delegation) for all form inputs — 100 inputs cost 1 listener.
+- Runs a single `querySelectorAll` combining all handler attribute selectors.
 
-`bindDom` uses several internal optimizations:
+## See also
 
-- **Event delegation**: Single `input` event listener on root (not per-input)
-- **Compiled selectors**: All handler attrs combined into one `querySelectorAll` call
-- **O(1) binding lookup**: WeakMap for element → binding resolution
-- **Auto DOM-ready**: Waits for `DOMContentLoaded` unless `{ immediate: true }`
-
-## Handler System
-
-User handlers extend the built-in set. They're merged via Map deduplication — if a user handler has the same `attr` as a built-in, it overrides the default.
-
-Arrays are auto-flattened one level, so factories like `classToggle()` that return arrays work directly:
-
-```javascript
-// classToggle('a', 'b') returns [{ attr: 'data-class-a', ... }, { attr: 'data-class-b', ... }]
-// Auto-flattened by bindDom
-bindDom(root, store, { handlers: [classToggle('a', 'b')] });
-```
-
-See the full [Handlers API reference](handlers.md) for available handlers and how to create custom ones.
+- [Handlers guide](../../guides/handlers.md) — writing custom handlers
+- [Two-way binding guide](../../guides/two-way-binding.md) — full form control reference
+- [show](../handlers/show.md), [classToggle](../handlers/classToggle.md), [stringAttr](../handlers/stringAttr.md)
 
 ---
 
 **← Previous: [state()](state.md)** | **Next: [effect()](effect.md) →**
-
-> **Deep Dive:** Why `data-*` attributes instead of custom directives? Read the [Design Decision](../../design/design-decisions.md#why-standards-only).

--- a/docs/api/core/effect.md
+++ b/docs/api/core/effect.md
@@ -1,105 +1,97 @@
-# effect(callback, deps?)
+# effect(fn)
 
-Runs a function immediately and re-runs it whenever dependencies change.
+Runs a function immediately and re-runs it whenever any store key it reads changes.
 
 ## Signature
 
-```typescript
-// Auto-tracking mode (default)
-function effect(callback: () => void): () => void;
-
-// Explicit deps mode (no magic)
-function effect(callback: () => void, deps: [store, ...keys][]): () => void;
+```ts
+function effect(
+  fn: () => void,
+  deps?: Array<[store: object, ...keys: string[]]>
+): () => void
 ```
+
+Imported from `lume-js`.
 
 ## Parameters
 
-- `callback` (Function): The function to run reactively.
-- `deps` (Optional Array): Explicit dependencies as `[store, 'key1', 'key2', ...]` tuples.
+- `fn` — The function to run reactively. Must be synchronous. Return value is ignored.
 
 ## Returns
 
-- A cleanup function that stops the effect.
+A dispose function. Call it to stop the effect and free its subscriptions.
 
----
+## How it works
 
-## Auto-Tracking Mode (Default)
+`effect` sets a global tracking context, runs `fn`, then clears it. Every store `get` that fires during the run registers the current effect as a subscriber for that key. On any subsequent write to a tracked key, the effect is queued in a microtask and re-runs. Before each re-run, previous subscriptions are torn down and rebuilt from the new read set, so stale dependencies are dropped automatically.
 
-Tracks dependencies automatically by detecting which state properties are accessed.
+You can also pass an explicit `deps` array of `[store, ...keys]` tuples to skip auto-tracking and subscribe to specific keys only.
 
-```javascript
-const store = state({ count: 0, name: 'Alice' });
+```js
+import { state, effect } from 'lume-js';
 
-const cleanup = effect(() => {
-  // Accessing store.count makes it a dependency
-  console.log(`The count is ${store.count}`);
+const store = state({ count: 0, name: 'Ada' });
+
+const stop = effect(() => {
+  console.log(`Count: ${store.count}`);
+  // store.name is NOT read, so it is NOT a dependency
 });
 
-store.count++; // ✓ Logs: "The count is 1"
-store.name = 'Bob'; // ✗ Does NOT trigger (name not accessed)
+store.count++;    // logs "Count: 1"
+store.name = 'Z'; // nothing — name is not tracked
+stop();           // effect stops
+store.count++;    // nothing — disposed
 ```
 
-**Best for:** UI updates, rendering logic.
+## Conditional dependencies
 
----
+Dependencies are determined by which keys are **actually read** in a given run. If a read is behind a condition, the subscription only exists while that branch is active.
 
-## Explicit Deps Mode (No Magic)
+```js
+const store = state({ show: true, value: 42 });
 
-You specify exactly what triggers re-runs. No auto-tracking occurs.
-
-```javascript
-const store = state({ count: 0, name: 'Alice' });
-
-const cleanup = effect(() => {
-  // Accessing store.name does NOT create a dependency
-  analytics.track('count', store.count, store.name);
-}, [[store, 'count']]);  // Only re-runs when count changes
-
-store.count++; // ✓ Effect re-runs
-store.name = 'Bob'; // ✗ Effect does NOT re-run
+effect(() => {
+  if (store.show) {
+    console.log(store.value); // only subscribed when show is true
+  }
+});
 ```
 
-**Best for:** Side-effects, logging, analytics, API calls.
+## Avoiding infinite loops
 
----
+Writing to a store key inside an effect that reads the same key causes an infinite loop. If you need to derive a value, use [`computed`](../addons/computed.md) instead. Reading one key and writing a different key is fine:
 
-## Multiple Dependencies
-
-```javascript
-// Multiple keys from same store
+```js
+// Reads store.a, writes store.b — no loop
 effect(() => {
-  console.log(store.a, store.b, store.c);
-}, [[store, 'a', 'b', 'c']]);
-
-// Multiple stores
-const userStore = state({ name: 'Alice' });
-const cartStore = state({ total: 0 });
-
-effect(() => {
-  console.log(`${userStore.name}'s cart: $${cartStore.total}`);
-}, [[userStore, 'name'], [cartStore, 'total']]);
-
-// Nested stores
-const app = state({ 
-  user: state({ profile: state({ name: 'Alice' }) }) 
+  store.b = store.a * 2;
 });
 
+// Reads and writes store.count — infinite loop
 effect(() => {
-  console.log(app.user.profile.name);
-}, [[app.user.profile, 'name']]);  // Reference the nested store directly
+  store.count = store.count + 1;
+});
 ```
 
+## Cleanup
+
+The dispose function returned by `effect()` tears down all subscriptions. Call it to stop the effect:
+
+```js
+const stop = effect(() => {
+  document.title = `Count: ${store.count}`;
+});
+
+// Later:
+stop(); // unsubscribes and stops re-running
+```
+
+## See also
+
+- [watch()](../addons/watch.md) — explicit single-key subscription (no auto-tracking)
+- [computed()](../addons/computed.md) — cached derived value
+- [How reactivity works](../../guides/reactivity.md)
+
 ---
 
-## Notes
-
-- Effects run asynchronously (microtask) to batch updates.
-- In explicit mode, `globalThis.__LUME_CURRENT_EFFECT__` is NOT set.
-- Clean up effects when done to prevent memory leaks.
-
----
-
-**← Previous: [bindDom()](bindDom.md)** | **Next: [computed()](../addons/computed.md) →**
-
-> **Deep Dive:** [Design Decision: Why two modes?](../../design/design-decisions.md#why-support-explicit-dependencies-in-effect)
-
+**← Previous: [bindDom()](bindDom.md)** | **Next: [watch()](../addons/watch.md) →**

--- a/docs/api/core/handlers.md
+++ b/docs/api/core/handlers.md
@@ -1,8 +1,8 @@
 # Handlers API
 
-> **Version:** 2.0.0-beta.1+  
-> **Import:** `import { ... } from 'lume-js/handlers'`  
-> **Size:** 0.33KB gzipped
+> **Version:** 2.0.0-beta.1+
+> **Import:** `import { ... } from 'lume-js/handlers'`
+> **Size:** 0.33 KB gzipped
 
 Handlers extend `bindDom()` with additional reactive `data-*` attributes. Each handler is a plain object — no framework API, no registration system.
 
@@ -42,19 +42,19 @@ A handler is any object with two properties:
 
 ```typescript
 interface Handler {
-  readonly attr: string;         // e.g., 'data-show', 'data-class-active'
-  apply(el: HTMLElement, val: any): void;  // Called with reactive value
+  readonly attr: string;                        // e.g., 'data-show', 'data-class-active'
+  apply(el: HTMLElement, val: any): void;       // Called with the reactive value
 }
 ```
 
-- `attr` — The `data-*` attribute name that triggers this handler
-- `apply` — Called immediately with the current value, then again whenever the state changes
+- `attr` — The `data-*` attribute name that triggers this handler.
+- `apply` — Called immediately with the current value, then again whenever the state changes.
 
 ## Ready-to-use Handlers
 
 ### `show`
 
-Shows element when state value is truthy (inverse of built-in `data-hidden`).
+Shows an element when the state value is truthy (inverse of the built-in `data-hidden`).
 
 ```javascript
 import { show } from 'lume-js/handlers';
@@ -87,7 +87,7 @@ bindDom(root, store, { handlers: [boolAttr('readonly'), boolAttr('open')] });
 
 **Behavior:** `el.toggleAttribute(name, Boolean(val))`
 
-> **Note:** Built-in handlers for `hidden`, `disabled`, `checked`, `required` use direct property assignment (`el.hidden = true`). The `boolAttr()` factory uses `toggleAttribute()` which works correctly with any attribute name regardless of camelCase property mapping.
+> **Note:** The built-in handlers for `hidden`, `disabled`, `checked`, and `required` use direct property assignment (`el.hidden = true`). The `boolAttr()` factory uses `toggleAttribute()`, which works correctly with any attribute name regardless of camelCase property mapping.
 
 ---
 
@@ -95,7 +95,7 @@ bindDom(root, store, { handlers: [boolAttr('readonly'), boolAttr('open')] });
 
 Creates a handler for a **boolean** ARIA attribute. Coerces values to `"true"` or `"false"` strings. Accepts the name with or without the `aria-` prefix.
 
-For string-valued ARIA attrs like `aria-label`, use `stringAttr('aria-label')` instead.
+For string-valued ARIA attributes like `aria-label`, use `stringAttr('aria-label')` instead.
 
 ```javascript
 import { ariaAttr } from 'lume-js/handlers';
@@ -132,13 +132,13 @@ bindDom(root, store, { handlers: [classToggle('active', 'loading', 'error')] });
 
 **Behavior:** `el.classList.toggle(name, Boolean(val))`
 
-Does **not** affect other classes on the element — only toggles the specified class.
+Does **not** affect other classes on the element — only the specified class is toggled.
 
 ---
 
 ### `stringAttr(name)`
 
-Creates a handler for any string attribute. Removes the attribute when value is `null` or `undefined`.
+Creates a handler for any string attribute. Removes the attribute when the value is `null` or `undefined`.
 
 ```javascript
 import { stringAttr } from 'lume-js/handlers';
@@ -194,7 +194,7 @@ bindDom(root, store, {
 
 ### `htmlAttrs()`
 
-One-import preset that enables **all standard HTML attributes** as reactive handlers. Includes boolean attrs, string attrs, ARIA attrs, and the `show` handler.
+A single-import preset that enables **all standard HTML attributes** as reactive handlers — boolean attrs, string attrs, ARIA attrs, and the `show` handler.
 
 ```javascript
 import { htmlAttrs } from 'lume-js/handlers';
@@ -235,7 +235,7 @@ Now use any `data-*` attribute without additional imports:
 | **ARIA (string)** | `label`, `describedby`, `labelledby`, `controls`, `owns`, `activedescendant`, `errormessage`, `current`, `live`, `relevant`, `haspopup`, `sort`, `autocomplete`, `orientation`, `valuenow`, `valuemin`, `valuemax`, `valuetext`, `details`, `flowto`, `colcount`, `colindex`, `colspan`, `rowcount`, `rowindex`, `rowspan`, `level`, `setsize`, `posinset`, `placeholder`, `roledescription`, `keyshortcuts`, `braillelabel`, `brailleroledescription` |
 | **Other** | `show` |
 
-> **ARIA boolean vs string:** Boolean ARIA attrs (like `aria-pressed`) are coerced to `"true"`/`"false"`. String ARIA attrs (like `aria-label`) pass through the actual value, and are removed when set to `null`/`undefined`.
+> **ARIA boolean vs string:** Boolean ARIA attrs (like `aria-pressed`) are coerced to `"true"`/`"false"`. String ARIA attrs (like `aria-label`) pass through the actual value and are removed when set to `null`/`undefined`.
 >
 > **When to use `htmlAttrs()`:** Great for prototyping and apps that use many different attributes. For production bundles where you want minimal overhead, cherry-pick individual handlers instead.
 
@@ -266,10 +266,10 @@ bindDom(root, store, { handlers: [tooltip, bgColor] });
 
 ## Handler Override
 
-User handlers override built-in handlers with the same `attr`. This lets you customize default behavior:
+User-supplied handlers override built-in handlers with the same `attr`. This lets you customize default behavior:
 
 ```javascript
-// Override data-hidden to use display:none instead of hidden property
+// Override data-hidden to use display:none instead of the hidden property
 const customHidden = {
   attr: 'data-hidden',
   apply(el, val) {
@@ -278,7 +278,6 @@ const customHidden = {
 };
 
 bindDom(root, store, { handlers: [customHidden] });
-// Now data-hidden uses style.display instead of el.hidden
 ```
 
 Built-in handlers that can be overridden: `data-hidden`, `data-disabled`, `data-checked`, `data-required`, `data-aria-expanded`, `data-aria-hidden`.
@@ -322,11 +321,10 @@ bindDom(root, store, {
 ```javascript
 import { htmlAttrs } from 'lume-js/handlers';
 
-// One import to enable all standard HTML attributes
 bindDom(root, store, { handlers: [htmlAttrs()] });
 ```
 
-### Multiple bindDom calls with different handlers
+### Multiple `bindDom` calls with different handlers
 
 ```javascript
 // Form section needs form handlers

--- a/docs/api/core/isReactive.md
+++ b/docs/api/core/isReactive.md
@@ -1,25 +1,24 @@
 # isReactive(value)
 
-Checks if a value is a Lume reactive proxy.
+Returns `true` if the value is a Lume reactive proxy created by `state()`.
 
 ## Signature
 
-```typescript
+```ts
 function isReactive(value: any): boolean;
 ```
 
 ## Parameters
 
-- `value` (any): The value to check.
+- `value` — The value to check.
 
 ## Returns
 
-- `true` if the value is a reactive proxy created by `state()`.
-- `false` otherwise.
+`true` if the value is a reactive proxy created by `state()`, `false` otherwise.
 
 ## Example
 
-```javascript
+```js
 import { state, isReactive } from 'lume-js';
 
 const raw = { count: 0 };
@@ -28,3 +27,5 @@ const store = state(raw);
 isReactive(store); // true
 isReactive(raw);   // false
 ```
+
+This is useful when writing utilities or plugins that need to accept either a raw object or an already-reactive store without double-wrapping it.

--- a/docs/api/core/plugins.md
+++ b/docs/api/core/plugins.md
@@ -1,9 +1,9 @@
 # Plugins API
 
-> **Version:** 2.0.0+  
+> **Version:** 2.0.0+
 > **Status:** Stable
 
-The plugin system allows you to extend Lume.js state with custom behaviors. Plugins can intercept and modify state operations, add logging, validation, persistence, and more.
+The plugin system lets you extend Lume state with custom behaviors — logging, validation, persistence, transformation, and more. Plugins intercept state operations through a small set of hooks.
 
 ## Table of Contents
 
@@ -44,12 +44,12 @@ A plugin is a plain object with a `name` property and optional hook functions:
 
 ```typescript
 interface Plugin {
-  name: string;                // Required: unique identifier
-  onInit?: () => void;         // Called when state is created
-  onGet?: (key: string, value: any) => any;  // Intercept get operations
-  onSet?: (key: string, newValue: any, oldValue: any) => any;  // Intercept set operations
-  onSubscribe?: (key: string) => void;  // Called when subscriber added
-  onNotify?: (key: string, value: any) => void;  // Before subscribers notified
+  name: string;                                                    // Required: unique identifier
+  onInit?: () => void;                                             // Called when state is created
+  onGet?: (key: string, value: any) => any;                       // Intercept reads
+  onSet?: (key: string, newValue: any, oldValue: any) => any;     // Intercept writes
+  onSubscribe?: (key: string) => void;                             // Called when a subscriber is added
+  onNotify?: (key: string, value: any) => void;                   // Before subscribers are notified
 }
 ```
 
@@ -57,12 +57,8 @@ interface Plugin {
 
 Called synchronously when the state object is created.
 
-**Use cases:**
-- Initialize plugin state
-- Set up external connections
-- Register global handlers
+**Use cases:** initialize plugin state, set up external connections, register global handlers.
 
-**Example:**
 ```javascript
 const plugin = {
   name: 'logger',
@@ -77,18 +73,13 @@ const plugin = {
 Called when a property is accessed, before the value is returned.
 
 **Parameters:**
-- `key` (string) - Property key being accessed
-- `value` (any) - Current value (possibly transformed by previous plugins)
+- `key` — Property key being accessed.
+- `value` — Current value (possibly transformed by earlier plugins in the chain).
 
-**Returns:** Transformed value or undefined to keep current value
+**Returns:** Transformed value, or the original `value` to pass it through unchanged.
 
-**Use cases:**
-- Transform values on read
-- Log property access
-- Implement computed properties
-- Lazy loading
+**Use cases:** transform values on read, log access, implement computed properties, lazy loading.
 
-**Example:**
 ```javascript
 const transformPlugin = {
   name: 'transform',
@@ -106,19 +97,14 @@ const transformPlugin = {
 Called when a property is updated, before subscribers are notified.
 
 **Parameters:**
-- `key` (string) - Property key being updated
-- `newValue` (any) - New value (possibly transformed by previous plugins)
-- `oldValue` (any) - Previous value
+- `key` — Property key being updated.
+- `newValue` — New value (possibly transformed by earlier plugins).
+- `oldValue` — Previous value.
 
-**Returns:** Transformed value or undefined to keep current value
+**Returns:** The value to store. Return `oldValue` to reject the change.
 
-**Use cases:**
-- Validate input
-- Transform values on write
-- Prevent updates
-- Track history
+**Use cases:** validate input, transform values on write, prevent updates, track history.
 
-**Example:**
 ```javascript
 const validationPlugin = {
   name: 'validation',
@@ -137,14 +123,10 @@ const validationPlugin = {
 Called when a new subscriber is added to a property.
 
 **Parameters:**
-- `key` (string) - Property key being subscribed to
+- `key` — Property key being subscribed to.
 
-**Use cases:**
-- Track active subscriptions
-- Lazy load data when needed
-- Initialize watchers
+**Use cases:** track active subscriptions, lazy load data, initialize watchers.
 
-**Example:**
 ```javascript
 const trackPlugin = {
   name: 'tracker',
@@ -156,23 +138,18 @@ const trackPlugin = {
 
 ### Hook: `onNotify(key, value)`
 
-Called during microtask flush, before subscribers are notified.
+Called during microtask flush, before subscribers are notified. This is the right place for side effects.
 
 **Parameters:**
-- `key` (string) - Property key that changed
-- `value` (any) - New value being notified
+- `key` — Property key that changed.
+- `value` — New value being notified.
 
-**Use cases:**
-- Log notifications
-- Sync with external systems
-- Trigger side effects
+**Use cases:** log notifications, sync with external systems, trigger side effects.
 
-**Example:**
 ```javascript
 const syncPlugin = {
   name: 'sync',
   onNotify: (key, value) => {
-    // Sync to server, localStorage, etc.
     localStorage.setItem(key, JSON.stringify(value));
   }
 };
@@ -180,27 +157,25 @@ const syncPlugin = {
 
 ## Hook Execution Order
 
-Hooks execute in a specific order during state operations:
-
-### Property Access (Get)
+### Property access (get)
 
 ```
 1. Property accessed: store.count
-2. onGet hooks (all plugins, in order)
-3. Value returned to caller
+2. onGet hooks run (all plugins, in registration order)
+3. Transformed value returned to caller
 ```
 
-### Property Update (Set)
+### Property update (set)
 
 ```
 1. Property set: store.count = 5
-2. onSet hooks (all plugins, in order)
-3. Value stored in state
+2. onSet hooks run (all plugins, in registration order)
+3. Final value stored
 4. Change queued for microtask
-5. --- Microtask boundary ---
-6. onNotify hooks (all plugins, in order)
-7. Subscribers notified
-8. Effects run (if any)
+--- microtask boundary ---
+5. onNotify hooks run (all plugins, in registration order)
+6. Subscribers notified
+7. Effects re-run
 ```
 
 ### Diagram
@@ -229,9 +204,9 @@ store.count = 5
 
 ## Chain Pattern
 
-When multiple plugins are registered, they form a chain where each plugin receives the output of the previous plugin.
+When multiple plugins are registered, each plugin receives the output of the previous one.
 
-### Get Chain
+### Get chain
 
 ```javascript
 const plugin1 = {
@@ -252,15 +227,13 @@ const store = state(
 console.log(store.count); // (5 * 2) + 10 = 20
 ```
 
-### Set Chain
+### Set chain
 
 ```javascript
 const plugin1 = {
   name: 'clamp',
   onSet: (key, value) => {
-    if (key === 'age') {
-      return Math.max(0, Math.min(150, value)); // Clamp 0-150
-    }
+    if (key === 'age') return Math.max(0, Math.min(150, value));
     return value;
   }
 };
@@ -268,9 +241,7 @@ const plugin1 = {
 const plugin2 = {
   name: 'round',
   onSet: (key, value) => {
-    if (key === 'age') {
-      return Math.round(value); // Round to integer
-    }
+    if (key === 'age') return Math.round(value);
     return value;
   }
 };
@@ -286,41 +257,36 @@ console.log(store.age); // Math.round(Math.min(150, 175.7)) = 150
 
 ## Best Practices
 
-### 1. Keep Plugins Focused
+### Keep plugins focused
 
 Each plugin should do one thing well.
 
 ```javascript
 // Good: Single responsibility
 const validationPlugin = { name: 'validation', onSet: validateData };
-const loggingPlugin = { name: 'logging', onGet: logAccess };
+const loggingPlugin    = { name: 'logging',    onGet: logAccess };
 
-// Bad: Mixed responsibilities
+// Avoid: Mixed responsibilities in one plugin
 const godPlugin = {
   name: 'everything',
-  onGet: (key, value) => { /* validate + log + transform + ... */ }
+  onGet: (key, value) => { /* validate + log + transform + … */ }
 };
 ```
 
-### 2. Return Early When Not Applicable
+### Return early for non-applicable keys
 
 ```javascript
 const ageValidator = {
   name: 'age-validator',
   onSet: (key, newValue, oldValue) => {
-    // Only validate age property
     if (key !== 'age') return newValue;
-    
-    // Validation logic
-    if (newValue < 0 || newValue > 150) {
-      return oldValue;
-    }
+    if (newValue < 0 || newValue > 150) return oldValue;
     return newValue;
   }
 };
 ```
 
-### 3. Handle Errors Gracefully
+### Handle errors gracefully
 
 Lume catches errors in plugin hooks and logs them, but your plugin should handle expected errors:
 
@@ -332,42 +298,39 @@ const safePlugin = {
       return JSON.parse(value);
     } catch (e) {
       console.warn(`Failed to parse ${key}:`, e);
-      return value; // Return original value
+      return value;
     }
   }
 };
 ```
 
-### 4. Avoid Side Effects in onGet
+### Keep `onGet` pure
 
-onGet runs frequently and should be pure when possible:
+`onGet` runs on every property read. Side effects here (fetch calls, writes to other keys) will fire far more often than you expect. Use `onNotify` for side effects instead.
 
 ```javascript
-// Good: Pure transformation
+// Good: pure transformation
 const plugin = {
   name: 'format',
-  onGet: (key, value) => value.toUpperCase()
+  onGet: (key, value) => typeof value === 'string' ? value.toUpperCase() : value
 };
 
-// Bad: Side effects
+// Avoid: side effects in onGet
 const plugin = {
   name: 'bad',
   onGet: (key, value) => {
-    fetch('/api/log', { method: 'POST', body: key }); // Side effect!
+    fetch('/api/log', { method: 'POST', body: key }); // fires on every read!
     return value;
   }
 };
 ```
 
-### 5. Use onNotify for Side Effects
-
-onNotify is designed for side effects like persistence:
+### Use `onNotify` for side effects
 
 ```javascript
 const persistPlugin = {
   name: 'persist',
   onNotify: (key, value) => {
-    // Side effects are OK here
     localStorage.setItem(key, JSON.stringify(value));
   }
 };
@@ -383,14 +346,14 @@ const validationPlugin = {
   onSet: (key, newValue, oldValue) => {
     const rules = {
       email: (v) => typeof v === 'string' && v.includes('@'),
-      age: (v) => typeof v === 'number' && v >= 0 && v <= 150
+      age:   (v) => typeof v === 'number' && v >= 0 && v <= 150
     };
-    
+
     if (rules[key] && !rules[key](newValue)) {
       console.error(`Validation failed for ${key}`);
-      return oldValue; // Reject change
+      return oldValue;
     }
-    
+
     return newValue;
   }
 };
@@ -408,7 +371,6 @@ const historyPlugin = {
   }
 };
 
-// Undo function
 function undo(store) {
   if (historyPlugin.stack.length > 0) {
     const { key, value } = historyPlugin.stack.pop();
@@ -422,50 +384,23 @@ function undo(store) {
 ```javascript
 const persistPlugin = {
   name: 'persist',
-  
+
   onInit: () => {
-    // Load from localStorage on init
     persistPlugin.loaded = true;
   },
-  
+
   onGet: (key, value) => {
-    // Lazy load from localStorage
     if (persistPlugin.loaded && value === undefined) {
       const stored = localStorage.getItem(key);
       return stored ? JSON.parse(stored) : value;
     }
     return value;
   },
-  
+
   onNotify: (key, value) => {
-    // Save to localStorage on change
     localStorage.setItem(key, JSON.stringify(value));
   }
 };
-```
-
-### Computed Properties
-
-```javascript
-const computedPlugin = {
-  name: 'computed',
-  onGet: (key, value) => {
-    if (key === 'fullName') {
-      // Access other properties to compute value
-      // Note: This creates a dependency!
-      const store = computedPlugin.store;
-      return `${store.firstName} ${store.lastName}`;
-    }
-    return value;
-  }
-};
-
-// Store reference for computed access
-const store = state(
-  { firstName: 'John', lastName: 'Doe', fullName: null },
-  { plugins: [computedPlugin] }
-);
-computedPlugin.store = store; // Store reference
 ```
 
 ### Transform / Normalize
@@ -478,7 +413,7 @@ const normalizePlugin = {
       return newValue.toLowerCase().trim();
     }
     if (key === 'phone' && typeof newValue === 'string') {
-      return newValue.replace(/\D/g, ''); // Remove non-digits
+      return newValue.replace(/\D/g, ''); // digits only
     }
     return newValue;
   }
@@ -487,29 +422,22 @@ const normalizePlugin = {
 
 ## Performance
 
-### Plugin Overhead
+Plugin hooks add minimal overhead — typically 10–30% per operation depending on complexity. Each hook call is synchronous, and multiple plugins execute sequentially.
 
-- Plugins add minimal overhead (~10-30% depending on complexity)
-- Each hook call is synchronous
-- Multiple plugins execute sequentially
-
-### Optimization Tips
-
-1. **Filter early**: Return immediately for non-applicable keys
-2. **Avoid heavy computations**: Keep hook logic lightweight
-3. **Cache when possible**: Store computed results
-4. **Limit plugin count**: Use 1-3 plugins for typical apps
-
-### Benchmarks
+**Tips:**
+- Filter early: return immediately for non-applicable keys.
+- Keep hook logic lightweight.
+- Cache computed results when needed.
+- For typical apps, 1–3 plugins is plenty.
 
 Typical overhead on a modern system (M1 Mac):
 
 | Operation | No Plugins | 1 Plugin | 3 Plugins | 10 Plugins |
 |-----------|------------|----------|-----------|------------|
-| Get | 0.001ms | 0.002ms | 0.004ms | 0.010ms |
-| Set | 0.002ms | 0.003ms | 0.006ms | 0.015ms |
+| Get | 0.001 ms | 0.002 ms | 0.004 ms | 0.010 ms |
+| Set | 0.002 ms | 0.003 ms | 0.006 ms | 0.015 ms |
 
-For 99% of applications, plugin overhead is negligible.
+For the vast majority of applications, plugin overhead is negligible.
 
 ## Error Handling
 
@@ -549,8 +477,7 @@ const store = state<{ count: number }>(
 );
 ```
 
-## See Also
+## See also
 
-- [Design Decisions](../../design/design-decisions.md) - Why plugins work this way
-- [Plugin Demo Example](../../examples/plugin-demo/) - Working examples
-- [State API](./state.md) - Core state documentation
+- [Design Decisions](../../design/design-decisions.md) — Why plugins work this way
+- [State API](./state.md) — Core state documentation

--- a/docs/api/core/state.md
+++ b/docs/api/core/state.md
@@ -1,115 +1,70 @@
-# state(initialState, options)
+# state(initialValue)
 
-Creates a reactive state object with optional plugin support.
+Creates a reactive proxy of a plain object.
 
 ## Signature
 
-```typescript
-function state<T extends object>(
-  initialState: T, 
-  options?: StateOptions
-): ReactiveState<T>;
-
-interface StateOptions {
-  plugins?: Plugin[];
-}
+```ts
+function state<T extends object>(initialValue: T, options?: { plugins?: any[] }): T
 ```
 
 ## Parameters
 
-- `initialState` (Object): The initial state object. Must be a plain object, not a primitive.
-- `options` (Object, optional): Configuration options
-  - `plugins` (Array): Array of plugins to extend state behavior
+- `initialValue` — A plain object. Must not be a primitive, class instance, `Map`, or `Set`.
+- `options.plugins` — Optional array of plugin objects to extend state behavior.
 
 ## Returns
 
-- A reactive Proxy of the `initialState` with `$subscribe` method.
+A `Proxy` of `initialValue` with identical shape. Reads inside an `effect` are tracked; writes notify subscribers.
 
 ## Description
 
-`state()` wraps the provided object in a Proxy. It intercepts property access and assignment to enable automatic dependency tracking for `effect()` and `computed()`.
+`state()` wraps the object in a `Proxy` that intercepts `get` and `set`. The `get` trap returns `target[key]` directly — it does **not** auto-wrap nested objects in a new proxy. Writes are batched via `queueMicrotask` and flush on the next microtask.
 
-## Examples
-
-### Basic Usage
-
-```javascript
+```js
 import { state } from 'lume-js';
 
+const store = state({ count: 0 });
+
+store.count;     // read — tracked inside an effect
+store.count = 5; // write — notification queued via microtask
+```
+
+## Nested reactivity
+
+Nested objects are **not** automatically reactive. The `get` trap returns the raw value — it does not wrap sub-objects in a proxy. To make a nested object reactive, wrap it in its own `state()` call:
+
+```js
+// NOT reactive — nested write is silent
 const store = state({
-  count: 0,
-  name: 'Lume'
+  settings: { theme: 'dark', lang: 'en' }
 });
+store.settings.theme = 'light'; // subscribers NOT notified
 
-store.count++; // Triggers updates
-```
-
-### Nested State
-
-Nested objects are **not** automatically reactive. You must wrap them in `state()` explicitly if you want them to be reactive.
-
-```javascript
+// Reactive — settings is its own proxy
 const store = state({
-  user: state({ // ✅ Nested state
-    name: 'Alice'
-  }),
-  settings: { // ❌ Plain object (not reactive)
-    theme: 'dark'
-  }
+  settings: state({ theme: 'dark', lang: 'en' })
 });
+store.settings.theme = 'light'; // notifies subscribers of 'theme'
 ```
 
-### Methods
+## What's not reactive
 
-Reactive state objects have a special method:
+| Type | Supported | Notes |
+|------|-----------|-------|
+| Plain objects (top-level keys) | Yes | Fully reactive |
+| Nested plain objects | Partial | Must be wrapped in `state()` for reactivity |
+| Arrays | Partial | Replacing the array key triggers; `push`/`splice` do not |
+| `Map` / `Set` | No | Use plain objects / arrays instead |
+| Class instances | Partial | Proxy wraps them, but private fields bypass reactivity |
+| Functions | No | Not proxied — store methods stay plain |
 
-#### `$subscribe(key, callback)`
+## See also
 
-Subscribes to changes on a specific key.
-
-- `key` (String): The property name to watch.
-- `callback` (Function): Called with `(newValue)` immediately and whenever it changes.
-- **Returns**: An unsubscribe function.
-
-```javascript
-const unsub = store.$subscribe('count', (val) => {
-  console.log('Count changed:', val);
-});
-
-// Later
-unsub();
-```
-
-### With Plugins (v2.0+)
-
-Extend state with custom behaviors using plugins:
-
-```javascript
-const debugPlugin = {
-  name: 'debug',
-  onGet: (key, value) => {
-    console.log(`GET ${key}:`, value);
-    return value;
-  },
-  onSet: (key, newValue, oldValue) => {
-    console.log(`SET ${key}:`, oldValue, '→', newValue);
-    return newValue;
-  }
-};
-
-const store = state(
-  { count: 0 },
-  { plugins: [debugPlugin] }
-);
-
-store.count = 5; // Logs: SET count: 0 → 5
-console.log(store.count); // Logs: GET count: 5
-```
-
-**See [Plugin Documentation](plugins.md) for full plugin API.**
+- [How reactivity works](../../guides/reactivity.md) — detailed explanation of the proxy internals
+- [effect()](effect.md) — auto-tracked side-effects
+- [watch()](../addons/watch.md) — explicit single-key watcher
 
 ---
 
-**← Previous: [Build Tic-Tac-Toe](../../tutorials/build-tic-tac-toe.md)** | **Next: [bindDom()](bindDom.md) →**
-
-> **Deep Dive:** Why does `state()` only accept objects? Read the [Design Decision](../../design/design-decisions.md#why-only-objects-in-state-not-primitives).
+**← Previous: [Performance](../../guides/performance.md)** | **Next: [bindDom()](bindDom.md) →**

--- a/docs/api/handlers/classToggle.md
+++ b/docs/api/handlers/classToggle.md
@@ -1,0 +1,87 @@
+# classToggle
+
+Adds or removes a CSS class on an element based on a store value. When the value is truthy, the class is added. When falsy, it's removed. The visual behavior stays entirely in your CSS.
+
+## Attribute
+
+`data-class-{name}="key"`
+
+## Import
+
+```js
+import { classToggle } from 'lume-js/handlers';
+```
+
+## Usage
+
+`classToggle` is a factory. Call it with the class name you want to control, then pass the result to `bindDom`:
+
+```js
+import { state, bindDom } from 'lume-js';
+import { classToggle } from 'lume-js/handlers';
+
+const store = state({ active: false, hasError: false, isSelected: false });
+
+bindDom(document.body, store, {
+  handlers: [
+    classToggle('active'),
+    classToggle('error'),
+    classToggle('selected')
+  ]
+});
+```
+
+```html
+<li data-class-active="active">Menu item</li>
+<input data-class-error="hasError" data-bind="email">
+<div data-class-selected="isSelected">Card</div>
+```
+
+When `store.active` is truthy, the `active` class is added. When falsy, it's removed.
+
+## Multiple classes at once
+
+Pass multiple class names to one call:
+
+```js
+bindDom(root, store, {
+  handlers: [classToggle('loading', 'disabled')]
+});
+```
+
+This registers two handlers: `data-class-loading` and `data-class-disabled`.
+
+## Class naming
+
+The handler strips `data-class-` from the attribute name to get the CSS class. The attribute `data-class-is-open` toggles the class `is-open`:
+
+```html
+<div data-class-is-open="menuOpen">Menu</div>
+```
+
+```js
+bindDom(root, store, { handlers: [classToggle('is-open')] });
+```
+
+## Compared to `data-hidden` / `data-show`
+
+`classToggle` is more flexible — you define the visual behavior entirely in CSS. Use it when the show/hide logic is better expressed as a class:
+
+```css
+.sidebar { width: 0; overflow: hidden; transition: width 0.2s; }
+.sidebar.open { width: 260px; }
+```
+
+```html
+<aside class="sidebar" data-class-open="sidebarOpen">…</aside>
+```
+
+## See also
+
+- [show](show.md)
+- [Handlers guide](../../guides/handlers.md)
+- [bindDom()](../core/bindDom.md)
+
+---
+
+**← Previous: [show](show.md)** | **Next: [stringAttr](stringAttr.md) →**

--- a/docs/api/handlers/show.md
+++ b/docs/api/handlers/show.md
@@ -1,0 +1,66 @@
+# show
+
+Hides or shows an element based on a store value. When the value is truthy, the element is visible. When falsy, it gets `hidden = true`. This is the inverse of the built-in `data-hidden` attribute.
+
+## Attribute
+
+`data-show="key"`
+
+## Import
+
+```js
+import { show } from 'lume-js/handlers';
+```
+
+## Usage
+
+```js
+import { state, bindDom } from 'lume-js';
+import { show } from 'lume-js/handlers';
+
+const store = state({ loggedIn: false, loading: true });
+
+bindDom(document.body, store, { handlers: [show] });
+```
+
+```html
+<nav data-show="loggedIn">
+  <a href="/dashboard">Dashboard</a>
+  <a href="/settings">Settings</a>
+</nav>
+
+<div class="spinner" data-show="loading">Loading…</div>
+```
+
+When `store.loggedIn` is `false`, the nav gets `hidden` set to `true`. When it becomes truthy, `hidden` is set to `false` and the element is shown.
+
+## Behavior
+
+| Value | Effect |
+|-------|--------|
+| Truthy | `el.hidden = false` (element shown) |
+| Falsy (`false`, `null`, `0`, `''`) | `el.hidden = true` (element hidden) |
+
+This uses the native `hidden` attribute mechanism, not inline `style.display`.
+
+## Compared to `data-hidden`
+
+`bindDom` has a built-in `data-hidden` attribute that sets `el.hidden = Boolean(val)`. The difference:
+
+| | `data-show` | `data-hidden` |
+|--|-------------|---------------|
+| Value meaning | truthy = visible | truthy = hidden |
+| Mechanism | `hidden` attribute | `hidden` attribute |
+| Import required | Yes | No |
+
+Use `data-show` when the condition is already in "visible" form (`isLoggedIn`, `hasResults`). Use `data-hidden` when it's in "hidden" form (`isLoading`, `isEmpty`).
+
+## See also
+
+- [classToggle](classToggle.md)
+- [Handlers guide](../../guides/handlers.md)
+- [bindDom()](../core/bindDom.md)
+
+---
+
+**← Previous: [repeat()](../addons/repeat.md)** | **Next: [classToggle](classToggle.md) →**

--- a/docs/api/handlers/stringAttr.md
+++ b/docs/api/handlers/stringAttr.md
@@ -1,0 +1,81 @@
+# stringAttr
+
+Sets an HTML attribute to a reactive store value. Whenever the value changes, `el.setAttribute(name, value)` is called automatically. Use this when you need to drive `href`, `src`, `alt`, or any other attribute from state.
+
+## Attribute
+
+`data-{name}="key"` → sets `el.setAttribute(name, value)`
+
+## Import
+
+```js
+import { stringAttr } from 'lume-js/handlers';
+```
+
+## Usage
+
+`stringAttr` is a factory. Call it with the attribute name you want to drive, then pass the result to `bindDom`:
+
+```js
+import { state, bindDom } from 'lume-js';
+import { stringAttr } from 'lume-js/handlers';
+
+const store = state({
+  profileUrl: '/user/ada',
+  avatarSrc: '/avatars/ada.png',
+  altText: 'Ada Lovelace'
+});
+
+bindDom(document.body, store, {
+  handlers: [
+    stringAttr('href'),
+    stringAttr('src'),
+    stringAttr('alt')
+  ]
+});
+```
+
+```html
+<a data-href="profileUrl">Profile</a>
+<img data-src="avatarSrc" data-alt="altText">
+```
+
+As `store.profileUrl` changes, `el.setAttribute('href', newValue)` is called automatically.
+
+## Null / undefined handling
+
+When the value is `null` or `undefined`, the attribute is **removed** (`el.removeAttribute(name)`):
+
+```js
+store.profileUrl = null; // <a> loses its href attribute entirely
+```
+
+## Common use cases
+
+```js
+bindDom(root, store, {
+  handlers: [
+    stringAttr('href'),    // <a data-href="url">
+    stringAttr('src'),     // <img data-src="src">, <script data-src="...">
+    stringAttr('alt'),     // <img data-alt="desc">
+    stringAttr('title'),   // tooltip text
+    stringAttr('type'),    // <button data-type="submit|button|reset">
+    stringAttr('target'),  // <a data-target="_blank">
+    stringAttr('value'),   // <option data-value="...">
+  ]
+});
+```
+
+## Compared to `data-bind`
+
+`data-bind` sets DOM **properties** (like `el.href`, `el.textContent`). `stringAttr` sets HTML **attributes** (like `el.setAttribute('href', ...)`). For most `href` and `src` use cases they behave the same, but attributes are sometimes needed for custom elements or ARIA.
+
+## See also
+
+- [Handlers guide](../../guides/handlers.md)
+- [bindDom()](../core/bindDom.md)
+- [show](show.md), [classToggle](classToggle.md)
+
+---
+
+**← Previous: [classToggle](classToggle.md)** | **Next: [Build a Todo app](../../tutorials/build-todo-app.md) →**

--- a/docs/guides/animations.md
+++ b/docs/guides/animations.md
@@ -1,17 +1,16 @@
 # Animations
 
-Lume.js works great with animation libraries like [GSAP](https://greensock.com/gsap/) or standard CSS transitions.
+Lume pairs well with CSS transitions and animation libraries like [GSAP](https://greensock.com/gsap/). Because state changes are plain property writes and effects are plain functions, there is nothing special to learn — hook in wherever you would normally trigger an animation.
 
 ## CSS Transitions
 
-The simplest way is to bind a class or style.
+The lightest approach: toggle a class in an `effect` and let CSS do the rest.
 
 ```javascript
 const store = state({ isOpen: false });
 
 effect(() => {
-  const el = document.getElementById('menu');
-  el.classList.toggle('open', store.isOpen);
+  document.getElementById('menu').classList.toggle('open', store.isOpen);
 });
 ```
 
@@ -25,20 +24,24 @@ effect(() => {
 }
 ```
 
+Set `store.isOpen = true` and the menu slides in. No extra API to learn.
+
 ## GSAP
 
-Use `effect()` or `$subscribe()` to trigger GSAP animations.
+Use `effect()` or `watch()` to trigger GSAP animations when state changes. `watch` is the cleaner choice when you need to react to a single key:
 
 ```javascript
 import gsap from 'gsap';
+import { watch } from 'lume-js/addons';
 
 const store = state({ x: 0 });
 
-// Animate whenever x changes
-store.$subscribe('x', (newX) => {
+watch(store, 'x', (newX) => {
   gsap.to('.box', { x: newX, duration: 0.5 });
 });
 ```
+
+Any other GSAP method (`gsap.from`, `gsap.timeline`, etc.) works the same way — just call it inside the callback.
 
 ---
 

--- a/docs/guides/core-concepts.md
+++ b/docs/guides/core-concepts.md
@@ -1,0 +1,100 @@
+# Core concepts
+
+Lume has three building blocks. Learn them once and you understand the whole library.
+
+## 1. State
+
+A **store** holds your app's data. Create one by passing a plain object to `state()`:
+
+```js
+import { state } from 'lume-js';
+
+const store = state({ count: 0, name: 'World' });
+```
+
+Read and write it exactly like a normal JavaScript object:
+
+```js
+store.count;       // read
+store.count = 5;   // write — Lume notifies everything watching this key
+```
+
+Lume only watches **top-level keys** of the store. If you need a nested object to be reactive too, wrap it in its own `state()` call:
+
+```js
+const store = state({
+  user: state({ name: 'Ada' })
+});
+
+store.user.name = 'Grace'; // works — user is its own reactive store
+```
+
+## 2. Bindings
+
+`bindDom()` connects your store to the DOM. It scans for `data-*` attributes and keeps them live — when the store changes, the page updates automatically.
+
+The built-in `data-bind` attribute is **two-way** on form controls and **one-way** (text content) on everything else:
+
+```html
+<span data-bind="count"></span>              <!-- displays store.count -->
+<input data-bind="name">                     <!-- reads and writes store.name -->
+<input type="checkbox" data-bind="agreed">   <!-- reads and writes store.agreed -->
+```
+
+For visibility, classes, attributes, and more, use **handlers** — or write your own. A handler is just a plain object with `attr` and `apply`. See [Handlers](handlers.md).
+
+## 3. Effects
+
+An **effect** runs a function immediately and re-runs it whenever the store data it read changes. You never list dependencies — Lume tracks them automatically.
+
+```js
+import { effect } from 'lume-js';
+
+effect(() => {
+  document.title = `${store.count} unread`;
+});
+// Runs once now, then again every time store.count changes.
+```
+
+The `lume-js/addons` package adds two more options when you need more control:
+
+**`watch(store, key, fn)`** — subscribe to a single key explicitly:
+
+```js
+import { watch } from 'lume-js/addons';
+
+watch(store, 'theme', (theme) => {
+  document.documentElement.dataset.theme = theme;
+});
+```
+
+**`computed(fn)`** — a cached value that updates when its dependencies change:
+
+```js
+import { computed } from 'lume-js/addons';
+
+const remaining = computed(() =>
+  store.todos.filter(t => !t.done).length
+);
+
+remaining.value; // always current, only recalculates when needed
+```
+
+## How it fits together
+
+Your store sits in the middle. Bindings and effects subscribe to it. When you change a store key, every subscriber for that key updates — and nothing else.
+
+```
+           you write store.count = 5
+                      │
+          ┌───────────┴───────────┐
+          │                       │
+    DOM bindings             effect(fn)
+   (spans, inputs…)         (re-runs fn)
+```
+
+No virtual DOM, no component tree, no build step required.
+
+---
+
+**← Previous: [Quick start](quick-start.md)** | **Next: [How reactivity works](reactivity.md) →**

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -1,0 +1,133 @@
+# FAQ
+
+## Is Lume.js production-ready?
+
+Lume 2.x is currently in beta. The core API (`state`, `bindDom`, `effect`) and all addons (`watch`, `computed`, `repeat`) are stable. The 1.x series is also stable and used in production.
+
+## Does Lume work without a build step?
+
+Yes — that's one of its main advantages. Import from a CDN and write plain JavaScript:
+
+```html
+<script type="module">
+  import { state, bindDom, effect } from 'https://cdn.jsdelivr.net/npm/lume-js/src/index.js';
+</script>
+```
+
+No bundler, no npm, no config.
+
+## Does Lume support TypeScript?
+
+Yes. Types are included in the package. No `@types/` install needed.
+
+## Can I use Lume with an existing server-rendered page?
+
+Yes — that's a primary use case. Attach `bindDom` to any element on the page and the rest of the page is untouched:
+
+```js
+const store = state({ open: false });
+bindDom(document.getElementById('nav'), store);
+```
+
+## How does Lume compare to Alpine.js?
+
+Both work inline with server-rendered HTML. Lume uses standard `data-*` attributes; Alpine uses `x-*` directives with a custom expression syntax. Lume is smaller (~2.4 KB vs ~15 KB gzipped) and has no custom expression evaluator — logic lives in plain JS, not attribute strings.
+
+## How does Lume compare to Vue 3's reactivity?
+
+Lume's core reactivity (`state`, `effect`, `watch`, `computed`) is conceptually similar to Vue's `reactive`/`watchEffect`/`watch`/`computed`. The main difference is that Lume has no component model or template compiler — it binds directly to the DOM via `data-*` attributes.
+
+## Can I use `Map` or `Set` in state?
+
+No. The Proxy only intercepts plain object and array operations. Use plain arrays instead of `Set`, and objects with string keys instead of `Map`.
+
+```js
+// Not reactive
+const store = state({ tags: new Set(['js', 'css']) });
+
+// Use an array
+const store = state({ tags: ['js', 'css'] });
+```
+
+## Why does my effect run more than I expect?
+
+Effects re-run for every key they read. If you read `store.a` and `store.b` inside one effect, it re-runs when either changes. Use `watch(store, 'key', fn)` when you need to react to exactly one key, or use `computed` to derive a single value that the effect reads.
+
+## How do I do conditional rendering?
+
+The simplest way is `data-show` or `data-hidden`. Note that `data-show` requires opting in to the `show` handler — it is not built into `bindDom` by default:
+
+```js
+import { state, bindDom } from 'lume-js';
+import { show } from 'lume-js/handlers';
+
+const store = state({ isLoggedIn: false });
+bindDom(document.body, store, { handlers: [show] });
+```
+
+```html
+<div data-show="isLoggedIn">Welcome back!</div>
+<div data-hidden="isLoggedIn">Please log in.</div>
+```
+
+For replacing entire sections, assign `innerHTML` inside an `effect`:
+
+```js
+effect(() => {
+  outlet.innerHTML = store.page === 'home' ? homeHTML : aboutHTML;
+});
+```
+
+## Does Lume support async effects?
+
+`effect` itself is synchronous — it runs its function immediately and tracks dependencies. For async work, trigger it from a `watch` callback:
+
+```js
+watch(store, 'userId', async (id) => {
+  const user = await fetch(`/api/users/${id}`).then(r => r.json());
+  store.userName = user.name;
+});
+```
+
+## How do I share state between multiple `bindDom` calls?
+
+Pass the same store object to each call:
+
+```js
+const store = state({ count: 0, theme: 'light' });
+
+bindDom(document.getElementById('header'), store);
+bindDom(document.getElementById('main'), store);
+bindDom(document.getElementById('footer'), store);
+```
+
+All three subtrees share the same reactive store. A write in one subtree updates all of them.
+
+## Can I have multiple independent stores?
+
+Yes — create as many `state()` objects as you need:
+
+```js
+const userStore = state({ name: 'Ada', role: 'admin' });
+const cartStore = state({ items: [], total: 0 });
+
+bindDom(document.getElementById('user-panel'), userStore);
+bindDom(document.getElementById('cart'), cartStore);
+```
+
+## How do I clean up when removing a component?
+
+Call the cleanup function returned by `bindDom` and dispose any effects:
+
+```js
+const cleanup = bindDom(el, store);
+const stopEffect = effect(() => { /* … */ });
+
+// When tearing down:
+cleanup();
+stopEffect();
+```
+
+---
+
+**← Previous: [Changelog](../../CHANGELOG.md)**

--- a/docs/guides/forms.md
+++ b/docs/guides/forms.md
@@ -1,8 +1,10 @@
 # Forms
 
-Lume.js makes form handling simple with two-way binding.
+Lume handles form state through the same `data-bind` attribute used everywhere else. There is no special form API — bindings are two-way on form controls by default.
 
-## Basic Inputs
+## Basic inputs
+
+Add `data-bind` to any form control and `bindDom` wires it up automatically.
 
 ```html
 <input data-bind="name">
@@ -13,7 +15,7 @@ Lume.js makes form handling simple with two-way binding.
 </select>
 ```
 
-```javascript
+```js
 const store = state({
   name: '',
   bio: '',
@@ -23,74 +25,64 @@ const store = state({
 bindDom(document.body, store);
 ```
 
-## Checkboxes & Radios
+## Checkboxes and radios
+
+Checkboxes bind to a boolean. Radio groups bind to a string value — whichever radio's `value` attribute matches the store value gets checked.
 
 ```html
-<!-- Single Checkbox (Boolean) -->
+<!-- Single checkbox — store.acceptedTerms === true | false -->
 <input type="checkbox" data-bind="acceptedTerms">
 
-<!-- Radio Buttons (String) -->
+<!-- Radio group — store.theme === 'light' | 'dark' -->
 <input type="radio" name="theme" value="light" data-bind="theme">
 <input type="radio" name="theme" value="dark" data-bind="theme">
 ```
 
 ## Validation
 
-You can use `effect()` or `$subscribe()` to validate inputs.
+Use `watch` to run validation logic whenever a specific field changes. Write the result back to an error key in the store.
 
-```javascript
+```js
+import { watch } from 'lume-js/addons';
+
 const store = state({
   email: '',
   error: ''
 });
 
-store.$subscribe('email', (email) => {
-  if (!email.includes('@')) {
-    store.error = 'Invalid email';
-  } else {
-    store.error = '';
-  }
+watch(store, 'email', (email) => {
+  store.error = email.includes('@') ? '' : 'Invalid email';
 });
+```
+
+```html
+<input data-bind="email" type="email">
+<span data-bind="error"></span>
 ```
 
 ## Submitting
 
-Use standard `submit` events.
+Use a standard `submit` event. The store already holds the current values — read them directly.
 
-```javascript
+```js
 document.querySelector('form').addEventListener('submit', (e) => {
   e.preventDefault();
   console.log('Submitting:', store.name, store.email);
 });
 ```
 
-## Reactive Form Attributes
+## Reactive form attributes
 
-Use built-in `data-*` attributes to control form state reactively:
+The built-in `data-hidden` and `data-disabled` attributes let you control form state reactively without extra imports:
 
 ```html
-<form id="signup">
-  <input data-bind="email" data-required="emailRequired">
-  <span data-bind="error"></span>
-  <button data-disabled="isSubmitting">Submit</button>
-  <div data-hidden="isSubmitting">Form content</div>
-</form>
+<button data-disabled="isSubmitting">Submit</button>
+<div data-hidden="isSubmitting">Form content</div>
 ```
 
-```javascript
-const store = state({
-  email: '',
-  error: '',
-  emailRequired: true,
-  isSubmitting: false
-});
+For `readonly` and other form attributes not covered by the built-ins, import `formHandlers`:
 
-bindDom(document.getElementById('signup'), store);
-```
-
-For additional form attributes like `readonly`, import from `lume-js/handlers`:
-
-```javascript
+```js
 import { formHandlers } from 'lume-js/handlers';
 
 bindDom(root, store, { handlers: formHandlers });
@@ -102,4 +94,4 @@ bindDom(root, store, { handlers: formHandlers });
 
 ---
 
-**← Previous: [API: repeat()](../api/addons/repeat.md)** | **Next: [Routing](routing.md) →**
+**← Previous: [Lists & repeat](lists.md)** | **Next: [Animations](animations.md) →**

--- a/docs/guides/handlers.md
+++ b/docs/guides/handlers.md
@@ -1,0 +1,125 @@
+# Handlers
+
+`bindDom` handles `data-bind`, `data-hidden`, `data-disabled`, and a handful of other built-in attributes. For anything else — showing elements, toggling classes, setting `href` or `src`, or any custom behavior — you use a **handler**.
+
+A handler is a plain object with two things: the attribute name it responds to, and a function that applies the reactive value to an element. That's the entire API.
+
+## Anatomy
+
+```js
+const myHandler = {
+  attr: 'data-tooltip',
+  apply(el, value) {
+    el.title = value ?? '';
+  }
+};
+```
+
+When `bindDom` scans the DOM and finds an element with `data-tooltip="someKey"`:
+
+1. It subscribes to `store.someKey`.
+2. It calls `apply(el, store.someKey)` immediately, then again on every subsequent change.
+
+## Built-in handlers
+
+The handlers below are exported from `lume-js/handlers`. They are opt-in — import only the ones you need.
+
+### `show` — `data-show`
+
+Sets `el.hidden = !Boolean(val)`: hides the element (via the `hidden` attribute) when the value is falsy.
+
+```js
+import { show } from 'lume-js/handlers';
+bindDom(root, store, { handlers: [show] });
+
+// HTML:
+// <div data-show="isVisible">Only when truthy</div>
+```
+
+### `classToggle(name)` — `data-class-{name}`
+
+Toggles a CSS class based on a truthy value. Factory — returns a handler for a specific class.
+
+```js
+import { classToggle } from 'lume-js/handlers';
+
+bindDom(root, store, {
+  handlers: [classToggle('active'), classToggle('error')]
+});
+
+// HTML:
+// <li data-class-active="isSelected">…</li>
+// <input data-class-error="hasError">
+```
+
+### `stringAttr(name)` — `data-{name}` → `{name}`
+
+Mirrors a reactive value to a string attribute. Perfect for `href`, `src`, `alt`, `title`.
+
+```js
+import { stringAttr } from 'lume-js/handlers';
+
+bindDom(root, store, {
+  handlers: [stringAttr('href'), stringAttr('src')]
+});
+
+// HTML:
+// <a data-href="profileUrl">Profile</a>
+// <img data-src="avatarUrl" alt="Avatar">
+```
+
+## Writing your own
+
+Any behavior you can describe as "this attribute controls this element property based on a reactive value" is a handler. The three examples below cover the most common patterns.
+
+### Example 1 — `data-disabled`
+
+```js
+const disabled = {
+  attr: 'data-disabled',
+  apply(el, value) {
+    el.toggleAttribute('disabled', Boolean(value));
+  }
+};
+```
+
+### Example 2 — `data-style-color`
+
+```js
+function styleProp(prop) {
+  return {
+    attr: `data-style-${prop}`,
+    apply(el, value) {
+      el.style.setProperty(prop, value ?? '');
+    }
+  };
+}
+
+bindDom(root, store, {
+  handlers: [styleProp('color'), styleProp('background-color')]
+});
+```
+
+### Example 3 — `data-format-currency`
+
+```js
+const formatCurrency = {
+  attr: 'data-format-currency',
+  apply(el, value) {
+    el.textContent = new Intl.NumberFormat('en-US', {
+      style: 'currency', currency: 'USD'
+    }).format(value ?? 0);
+  }
+};
+
+// HTML:
+// <span data-format-currency="price"></span>
+```
+
+## Handler ordering
+
+Handlers are applied in the order you pass them. If two handlers share the same `attr` name, the last one wins — it replaces the earlier one. This is how you override a built-in handler: pass your replacement after the built-in in the `handlers` array.
+
+---
+
+**← Previous: [How reactivity works](reactivity.md)** | **Next: [Two-way binding](two-way-binding.md) →**

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,0 +1,97 @@
+# Installation
+
+Lume.js ships as ES modules with TypeScript declarations. The simplest way to get started is a CDN import — no npm, no build tool, nothing to install. If your project already uses a bundler, npm works too.
+
+## Via CDN — no build step
+
+Drop a `<script type="module">` into any HTML file and you're done:
+
+```html
+<script type="module">
+  import { state, bindDom, effect } from 'https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.1/src/index.js';
+</script>
+```
+
+### Pin the version
+
+For production, pin to an exact version so your page can't break on a new release. The `@next` tag always resolves to the latest beta; omitting a tag gives the latest stable.
+
+```html
+<!-- exact version (recommended for production) -->
+'https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.1/src/index.js'
+
+<!-- latest stable -->
+'https://cdn.jsdelivr.net/npm/lume-js/src/index.js'
+
+<!-- latest beta -->
+'https://cdn.jsdelivr.net/npm/lume-js@next/src/index.js'
+```
+
+### Import map (recommended for CDN projects)
+
+If your page imports from more than one Lume subpath, an import map removes the long URLs from your code and keeps everything readable:
+
+```html
+<script type="importmap">
+{
+  "imports": {
+    "lume-js":          "https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.1/src/index.js",
+    "lume-js/addons":   "https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.1/src/addons/index.js",
+    "lume-js/handlers": "https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.1/src/handlers/index.js"
+  }
+}
+</script>
+<script type="module">
+  import { state, bindDom } from 'lume-js';
+  import { watch, computed } from 'lume-js/addons';
+  import { classToggle }    from 'lume-js/handlers';
+</script>
+```
+
+## Via npm
+
+If you're working in a project with a bundler (Vite, Rollup, esbuild, webpack):
+
+```bash
+npm install lume-js@next
+# or
+pnpm add lume-js@next
+# or
+yarn add lume-js@next
+```
+
+Then import as usual:
+
+```js
+import { state, bindDom } from 'lume-js';
+import { watch, computed } from 'lume-js/addons';
+import { show, classToggle, stringAttr } from 'lume-js/handlers';
+```
+
+## Package exports
+
+| Subpath | What's inside |
+|---------|---------------|
+| `lume-js` | `state`, `bindDom`, `effect`, `isReactive` |
+| `lume-js/addons` | `watch`, `computed`, `repeat`, `createDebugPlugin`, `debug`, `defaultFocusPreservation`, `defaultScrollPreservation` |
+| `lume-js/handlers` | `show`, `classToggle`, `stringAttr`, `boolAttr`, `ariaAttr`, `htmlAttrs`, `formHandlers`, `a11yHandlers` |
+
+## Browser support
+
+Lume targets evergreen browsers: Chrome 49+, Firefox 18+, Safari 10+, Edge 79+. IE11 is **not** supported. Lume uses `Proxy` for reactivity, and `Proxy` cannot be polyfilled.
+
+## TypeScript
+
+Type declarations ship with the package — no separate `@types/` install needed. Stores infer their shape from the object you pass to `state()`:
+
+```ts
+import { state } from 'lume-js';
+
+const store = state({ count: 0, name: 'Ada' });
+store.count = 'two'; // ✗ Type 'string' is not assignable to type 'number'
+store.unknown;       // ✗ Property 'unknown' does not exist
+```
+
+---
+
+**← Previous: [Introduction](../README.md)** | **Next: [Quick start](quick-start.md) →**

--- a/docs/guides/lists.md
+++ b/docs/guides/lists.md
@@ -1,0 +1,84 @@
+# Lists & repeat
+
+The `repeat` addon renders a reactive array into the DOM. Rather than rebuilding the list on every change, it keys each element by a stable ID and only touches what actually changed. This keeps long lists fast and preserves focus and input state across updates.
+
+## Basic usage
+
+```js
+import { state } from 'lume-js';
+import { repeat } from 'lume-js/addons';
+
+const store = state({
+  todos: [
+    { id: 1, text: 'Buy milk', done: false },
+    { id: 2, text: 'Walk dog', done: true  },
+  ]
+});
+
+repeat(document.getElementById('todo-list'), store, 'todos', {
+  key: (todo) => todo.id,
+  element: 'li',
+  render: (todo, el) => {
+    el.textContent = todo.text;           // mutate el directly
+    el.classList.toggle('done', todo.done);
+  }
+});
+```
+
+The `render` function receives `(item, el, index)` and should mutate `el` directly. It is called once when the element is first created, and again whenever that item's data changes.
+
+## Options
+
+| Option | Required | Notes |
+|--------|----------|-------|
+| `key` | ✅ | `(item) => string | number` — returns a stable unique ID per item. Use a database ID, never array index. |
+| `render` | One of | `(item, el, index) => void` — simple pattern, mutates `el` for new and updated items. |
+| `create` | One of | `(item, el, index) => void` — called once when an element is created. Set DOM structure and event listeners here. |
+| `update` | One of | `(item, el, index, { isFirstRender }) => void` — called on every data change. Bind data here. |
+| `element` | — | Tag name or factory for the wrapper element. Default: `'div'`. |
+
+Use `render` alone for simple, read-only lists. Use `create` + `update` for lists that have interactive elements (buttons, checkboxes) — `create` runs once per DOM element so you only attach listeners once, and `update` runs on every data change to keep the display in sync.
+
+## Updating the list
+
+`repeat` subscribes to the array key on the store. To trigger a re-render, **replace the array** with a new reference — in-place mutations like `push` or `splice` are invisible to Lume because the array reference does not change:
+
+```js
+// ❌ Mutations — NOT reactive, repeat() will not re-render
+store.todos.push(newTodo);
+store.todos.splice(0, 1);
+
+// ✅ Immutable replacement — triggers repeat() to re-render
+store.todos = [...store.todos, newTodo];           // append
+store.todos = store.todos.filter(t => t.id !== id); // remove
+store.todos = store.todos.map(t =>                  // update item
+  t.id === id ? { ...t, done: true } : t
+);
+```
+
+When the new array is set, `repeat` diffs by key and performs minimal DOM operations:
+
+| Change | DOM effect |
+|----------|-----------|
+| New key added | New element appended/inserted |
+| Key removed | Element removed |
+| Same keys, reordered | Existing nodes moved, `update` fires (index changed) |
+| Same key, item ref changed | `update` callback fires for that row |
+
+## Caveats
+
+- **Keys must be unique.** Duplicate keys log a warning and cause two items to share one DOM element, which produces incorrect rendering.
+- **Each rendered item must have exactly one root element.** Wrap multi-element fragments in a `<li>` or `<div>`.
+
+> **See it running →**
+> [Todo app tutorial](../tutorials/build-todo-app.md) and [Tic-Tac-Toe tutorial](../tutorials/build-tic-tac-toe.md) both use `repeat`.
+
+## See also
+
+- [repeat() API reference](../api/addons/repeat.md) — full signature, create+update pattern, array operations table
+- [computed()](../api/addons/computed.md) — pass a computed as the store to filter a list reactively
+- [Performance](performance.md) — why `repeat` beats `innerHTML` for dynamic lists
+
+---
+
+**← Previous: [Two-way binding](two-way-binding.md)** | **Next: [Performance](performance.md) →**

--- a/docs/guides/migration.md
+++ b/docs/guides/migration.md
@@ -1,0 +1,36 @@
+# Migrating from 1.x
+
+Lume 2.0 is a near-complete rewrite. The internals are faster and the architecture is cleaner — but the core API is fully backward compatible, so migrating is straightforward.
+
+## Breaking changes
+
+The only required change is bumping the version in `package.json`:
+
+```diff
+   "dependencies": {
+-    "lume-js": "^1.0.0"
++    "lume-js": "^2.0.0"
+   }
+```
+
+Everything else continues to work without modification.
+
+## New in 2.x
+
+- `watch(store, key, fn)` — explicit single-key watcher; callback receives `(newValue)` and fires immediately on subscribe
+- `computed()` with `.dispose()` method
+- `data-show` attribute (via `show` handler) — conditional visibility, positive counterpart to `data-hidden`
+- `data-class-*` attributes (via `classToggle()` factory) — per-class CSS toggle (e.g. `data-class-active`)
+- `show` handler — import from `lume-js/handlers`, pass to `bindDom` via the `handlers` option
+- `classToggle()` handler factory — import from `lume-js/handlers`
+- `stringAttr` handler
+
+## Unchanged
+
+- `state(obj)` — same API, smarter internals
+- `bindDom(root, store, { handlers })` — same API
+- `data-bind` attribute name
+
+---
+
+**← Previous: [Build Tic-Tac-Toe](../tutorials/build-tic-tac-toe.md)** | **Next: [Changelog](../../CHANGELOG.md) →**

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -1,48 +1,95 @@
 # Performance
 
-Lume.js is fast by default, but here are some tips for large applications.
+Lume's update model is O(subscribers) — only the effects that read a changed key re-run, nothing else. The patterns below keep that guarantee working well as your app grows.
 
-## 1. Use `repeat` for Lists
+## Use `repeat` for lists
 
-Never use `innerHTML` to render large lists. It destroys and recreates DOM elements. Use the `repeat` addon, which reuses DOM elements.
+`innerHTML` rebuilds the entire list on every change — event listeners, focus state, and scroll position are all destroyed. `repeat` keys elements by ID and only touches what changed.
 
-## 2. Use `computed` for Expensive Calculations
+```js
+import { repeat } from 'lume-js/addons';
 
-If you have a heavy calculation (like filtering a large list), wrap it in `computed()`. It will only re-calculate when dependencies change.
+// Keyed DOM reuse — only changed rows re-render
+repeat(listEl, store, 'todos', {
+  key: todo => todo.id,
+  render: (todo, el) => { el.textContent = todo.text; }
+});
 
-```javascript
-// Good
-const filtered = computed(() => items.filter(...));
-
-// Bad (runs on every render if inside effect)
+// Destroys and recreates every node on every update
 effect(() => {
-  const filtered = items.filter(...); 
+  listEl.innerHTML = store.todos.map(t => `<li>${t.text}</li>`).join('');
 });
 ```
 
-## 3. Batch Updates
+## Use `computed` for expensive derivations
 
-Lume automatically batches updates in the same microtask.
+`computed` caches its result and only re-evaluates when its dependencies change. If multiple effects read the same derived value, the underlying function runs once, not once per effect.
 
-```javascript
-// Only triggers ONE update
-store.count++;
-store.count++;
-store.count++;
+```js
+import { computed } from 'lume-js/addons';
+
+// Filters once, caches until todos changes
+const remaining = computed(() => store.todos.filter(t => !t.done).length);
+
+// Re-filters inside every effect that reads it
+effect(() => {
+  const count = store.todos.filter(t => !t.done).length;
+  badge.textContent = count;
+});
 ```
 
-## 4. Event Delegation (Automatic)
+## Keep state flat
 
-`bindDom` uses event delegation internally — a single `input` listener on the root element handles all form inputs. This means:
+Lume does **not** auto-proxy nested objects — only top-level keys on a `state()` proxy trigger subscribers. Deep nesting means you must wrap each nested object in its own `state()` call for reactivity, which adds overhead and complexity.
 
-- 100 inputs = 1 event listener (not 100)
-- No extra work needed — it's automatic
-- Efficient memory usage for large forms
+```js
+// Flat — easy to subscribe precisely
+const store = state({
+  userId: 1,
+  userName: 'Ada',
+  userEmail: 'ada@example.com',
+});
 
-## 5. Avoid Deeply Nested State
+// Deep — fine for nested data, avoid for hot-path state
+const store = state({
+  user: { profile: { contact: { email: 'ada@example.com' } } }
+});
+```
 
-While supported, deeply nested state can be harder to manage. Try to keep your state flat where possible.
+## Scope `bindDom` narrowly
+
+`bindDom` scans the subtree with `querySelectorAll`. Binding a small component root is faster than binding `document.body` for a large page.
+
+```js
+// Only scans the modal subtree
+bindDom(document.getElementById('modal'), store);
+
+// Scans the entire document
+bindDom(document.body, store);
+```
+
+## Event delegation is automatic
+
+`bindDom` attaches a single `input` event listener at the root — not one per form control. One hundred inputs cost one listener. There is nothing to configure.
+
+```js
+// All 100 inputs share one listener — nothing extra to do
+bindDom(formRoot, store);
+```
+
+## Cleanup when done
+
+Every `effect` and `bindDom` call returns a dispose function. Call it when the component unmounts to prevent memory leaks.
+
+```js
+const stopEffect = effect(() => { /* … */ });
+const cleanupDom = bindDom(el, store);
+
+// When tearing down:
+stopEffect();
+cleanupDom();
+```
 
 ---
 
-**← Previous: [Testing](testing.md)** | **[Back to Home](../../README.md)**
+**← Previous: [Lists & repeat](lists.md)** | **Next: [state()](../api/core/state.md) →**

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -1,0 +1,61 @@
+# Quick start
+
+Five minutes from nothing to a working reactive app. Every line is explained.
+
+## Step 1 — Plain HTML
+
+Write HTML the way you always would. No custom elements, no special syntax. The only Lume-specific thing is the `data-bind` attribute — and it's a standard `data-*` attribute, so validators won't complain.
+
+```html
+<div id="app">
+  <h1>Hello, <span data-bind="name"></span>!</h1>
+  <input data-bind="name">
+  <p>You've clicked <span data-bind="count"></span> times.</p>
+  <button onclick="store.count++">Click</button>
+</div>
+```
+
+## Step 2 — Create a store
+
+```js
+import { state } from 'lume-js';
+const store = state({ name: 'World', count: 0 });
+```
+
+`state()` returns a **reactive proxy**. Reading a property inside an effect subscribes to it; writing a property notifies subscribers. To make a nested object reactive, wrap it in its own `state()` call.
+
+## Step 3 — Bind to the DOM
+
+```js
+import { bindDom } from 'lume-js';
+bindDom(document.getElementById('app'), store);
+```
+
+`bindDom()` walks the root element, finds every `data-bind`, and wires it up. On form controls (`<input>`, `<textarea>`, `<select>`, checkboxes, radios) the binding is two-way — user input updates the store, and store changes update the element. On everything else it sets `textContent`.
+
+## Step 4 — Expose the store (optional)
+
+The `onclick="store.count++"` in Step 1 needs `store` to be accessible inline. Put it on `window` to make that work:
+
+```js
+window.store = store;
+```
+
+Prefer to keep things tidy? Use `addEventListener` and keep the store in a closure. Either approach works fine.
+
+## Step 5 — Open it in a browser
+
+No build step needed. Open the HTML file directly. Type in the input — the heading updates live. Click the button — the counter increments. That's the complete reactive loop.
+
+> **This is all you need for most apps.**
+> Lists, conditionals, classes, styles, and custom attributes are opt-in additions on top of this base.
+
+## What's next
+
+- [Core concepts](core-concepts.md) — the three primitives (state, bindings, effects).
+- [How reactivity works](reactivity.md) — under the hood.
+- [Build a Todo app](../tutorials/build-todo-app.md) — applies everything so far to a real app.
+
+---
+
+**← Previous: [Installation](installation.md)** | **Next: [Core concepts](core-concepts.md) →**

--- a/docs/guides/reactivity.md
+++ b/docs/guides/reactivity.md
@@ -1,0 +1,98 @@
+# How reactivity works
+
+Lume's reactivity is a thin layer over JavaScript's built-in `Proxy`. This page explains exactly what happens on a read, a write, and inside an effect. You don't need to know this to use Lume, but understanding it helps when debugging unexpected behavior.
+
+## The Proxy
+
+`state(obj)` returns `new Proxy(obj, handlers)`. The handlers intercept two traps:
+
+```js
+// Simplified pseudocode of what state() does
+function state(target) {
+  return new Proxy(target, {
+    get(obj, key) {
+      track(obj, key);           // register current effect
+      return obj[key];           // return raw value (no auto-nested proxy)
+    },
+    set(obj, key, value) {
+      const prev = obj[key];
+      if (Object.is(prev, value)) return true;  // no-op on identity
+      obj[key] = value;
+      scheduleFlush(obj, key, value);  // notify via queueMicrotask
+      return true;
+    }
+  });
+}
+```
+
+## Tracking
+
+When an effect starts running, Lume sets a global context (`globalThis.__LUME_CURRENT_EFFECT__`) to point at that effect. On every property read, the proxy checks for an active context and registers the effect as a subscriber for that key.
+
+```js
+effect(() => {
+  //        │
+  //        ├─ current effect context set
+  //        │
+  console.log(store.a + store.b);
+  //                ▲          ▲
+  //                │          └─ track: register effect as listener for 'b'
+  //                └─ track: register effect as listener for 'a'
+  //
+  //  current effect context cleared
+});
+```
+
+After the function finishes, the context is cleared. Writing to a store key inside an effect does not register a new subscription — only reads do.
+
+## Triggering
+
+On write, Lume queues the notification with `queueMicrotask`. On the next microtask, it calls every subscriber registered for that key. DOM updates therefore happen after the current synchronous JavaScript task finishes.
+
+## Nested objects
+
+Nested objects are **not** automatically reactive. The `get` trap returns `target[key]` directly without wrapping it in a new proxy. To make a nested object reactive, wrap it in its own `state()` call:
+
+```js
+// ❌ NOT reactive — nested write will NOT notify
+const bad = state({ user: { name: 'Ada' } });
+bad.user.name = 'Z'; // silent: no notification
+
+// ✅ Reactive — user is its own proxy
+const good = state({ user: state({ name: 'Ada' }) });
+good.user.name = 'Z'; // notifies subscribers of 'name'
+```
+
+Arrays stored on the store are reactive at the top level — replacing the array key triggers subscribers. Mutations *inside* the array (such as `push`) do **not** trigger, because the proxy only watches the key on the parent object, not the contents of the value:
+
+```js
+const store = state({ todos: [] });
+
+// ✅ Reactive — replaces the top-level key
+store.todos = [...store.todos, { text: 'buy milk' }];
+
+// ❌ NOT reactive — mutates the raw array directly
+store.todos.push({ text: 'buy milk' }); // subscribers NOT notified
+```
+
+## What is not reactive
+
+- **`Map` and `Set`** — not supported. Use plain arrays instead of `Set`, and plain objects instead of `Map`.
+- **Class instances** with private fields — the Proxy wraps the instance, but internal `this` references may read the private backing store directly and bypass the proxy.
+- **Functions stored on the store** — methods stay plain and are not proxied.
+
+## Cleanup
+
+Both `effect` and `bindDom` return a dispose function. Call it when the associated component or UI section is removed from the page to prevent memory leaks.
+
+```js
+const stop = effect(() => { /* … */ });
+stop();     // unsubscribes and stops re-running
+
+const cleanup = bindDom(root, store);
+cleanup(); // removes ALL bindings inside root
+```
+
+---
+
+**← Previous: [Core concepts](core-concepts.md)** | **Next: [Handlers](handlers.md) →**

--- a/docs/guides/routing.md
+++ b/docs/guides/routing.md
@@ -1,10 +1,10 @@
 # Routing
 
-Lume.js does not have a built-in router, but it's easy to build one or use an existing one.
+Lume does not include a router, and it does not need to. Routing is just state — store the current route in a `state()` object and react to it with `effect()`. Two patterns cover most use cases.
 
-## Hash-based Routing (Simple)
+## Hash-based routing
 
-You can use the URL hash (`#`) to determine which "page" to show.
+The simplest approach uses the URL hash (`#`). No server configuration required.
 
 ```javascript
 const store = state({
@@ -17,24 +17,26 @@ function handleHash() {
 }
 
 window.addEventListener('hashchange', handleHash);
-handleHash(); // Handle initial load
+handleHash(); // sync with the URL on first load
 ```
 
-Then, use `effect()` to show/hide content:
+Then use `effect()` to show or hide content based on the current route:
 
 ```javascript
 effect(() => {
-  document.getElementById('home-page').style.display = 
+  document.getElementById('home-page').style.display =
     store.route === 'home' ? 'block' : 'none';
-    
-  document.getElementById('about-page').style.display = 
+
+  document.getElementById('about-page').style.display =
     store.route === 'about' ? 'block' : 'none';
 });
 ```
 
-## History API (Advanced)
+Navigating to `#about` sets `store.route = 'about'` and the effect re-runs automatically.
 
-For cleaner URLs (no `#`), use the History API. You'll need to intercept link clicks.
+## History API (clean URLs)
+
+For URLs without a `#`, use the History API. You need to intercept link clicks to prevent a full page reload, and handle the browser back button via `popstate`.
 
 ```javascript
 document.addEventListener('click', (e) => {
@@ -50,6 +52,8 @@ window.addEventListener('popstate', () => {
   store.route = window.location.pathname;
 });
 ```
+
+Your server must return the same HTML file for all routes so that a direct visit or page refresh still works. This is a standard requirement for any single-page app using the History API.
 
 ---
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,10 +1,10 @@
 # Testing
 
-Since Lume.js uses standard JavaScript objects and DOM, testing is straightforward.
+Lume uses standard JavaScript objects and the standard DOM, so testing requires no special setup. Unit tests run without a DOM, and DOM tests work with any environment that provides one (Vitest ships with jsdom).
 
-## Unit Testing State
+## Unit testing state
 
-You can test your state logic without any DOM.
+State logic is plain JavaScript — test it directly without touching the DOM.
 
 ```javascript
 import { state } from 'lume-js';
@@ -17,9 +17,9 @@ test('increment count', () => {
 });
 ```
 
-## Testing DOM Updates
+## Testing DOM updates
 
-You can use `jsdom` (included in Vitest) to test DOM updates.
+Lume batches DOM updates via `queueMicrotask`, so after writing to the store you need to yield to the microtask queue before asserting. A zero-millisecond `setTimeout` is the simplest way to do this.
 
 ```javascript
 import { state, bindDom } from 'lume-js';
@@ -30,15 +30,13 @@ test('updates DOM', async () => {
   const store = state({ text: 'Hello' });
   bindDom(document.body, store);
 
-  // Initial render
   expect(document.querySelector('span').textContent).toBe('Hello');
 
-  // Update
   store.text = 'World';
-  
-  // Wait for microtask (Lume updates are async)
+
+  // Wait for the microtask flush
   await new Promise(resolve => setTimeout(resolve, 0));
-  
+
   expect(document.querySelector('span').textContent).toBe('World');
 });
 ```

--- a/docs/guides/two-way-binding.md
+++ b/docs/guides/two-way-binding.md
@@ -1,0 +1,75 @@
+# Two-way binding
+
+A single `data-bind` attribute handles all form controls. Lume inspects the element type and wires the correct DOM property and event automatically — you don't need to configure anything.
+
+## The rules
+
+| Element | Property | Event |
+|---------|----------|-------|
+| `<input>` (text, email, password, search, tel, url) | `value` | `input` |
+| `<input type="checkbox">` | `checked` | `input` |
+| `<input type="radio">` | `checked` (by value) | `input` |
+| `<input type="number">` | `valueAsNumber` | `input` |
+| `<input type="range">` | `valueAsNumber` | `input` |
+| `<input type="date">` | `value` | `input` |
+| `<textarea>` | `value` | `input` |
+| `<select>` | `value` | `input` |
+| Anything else | `textContent` | (one-way) |
+
+## Text inputs
+
+```html
+<input data-bind="username" placeholder="Username">
+<input data-bind="email" type="email">
+<textarea data-bind="bio"></textarea>
+```
+
+## Checkboxes
+
+```html
+<input type="checkbox" data-bind="agreed">
+<!-- store.agreed === true | false -->
+```
+
+## Radio groups
+
+```html
+<input type="radio" name="size" data-bind="size" value="sm"> Small
+<input type="radio" name="size" data-bind="size" value="md"> Medium
+<input type="radio" name="size" data-bind="size" value="lg"> Large
+<!-- store.size === 'md' -->
+```
+
+## Selects
+
+```html
+<select data-bind="country">
+  <option value="us">United States</option>
+  <option value="gb">United Kingdom</option>
+  <option value="jp">Japan</option>
+</select>
+```
+
+## Number inputs
+
+Lume binds number inputs to `valueAsNumber`, so store values stay numbers — no manual parsing needed:
+
+```html
+<input type="number" data-bind="age">
+<!-- store.age === 42  (a number, not the string '42') -->
+```
+
+## One-way bindings
+
+Any element that is not a form control gets `textContent` set from the store. No event is attached — the element never writes back.
+
+```html
+<h1 data-bind="title"></h1>
+<p>Count: <span data-bind="count"></span></p>
+```
+
+To set an HTML attribute (like `href` or `src`) reactively, use the [`stringAttr`](../api/handlers/stringAttr.md) handler instead.
+
+---
+
+**← Previous: [Handlers](handlers.md)** | **Next: [Lists & repeat](lists.md) →**

--- a/docs/tutorials/build-tic-tac-toe.md
+++ b/docs/tutorials/build-tic-tac-toe.md
@@ -1,6 +1,6 @@
 # Tutorial: Tic-Tac-Toe
 
-This tutorial will guide you through building a complete Tic-Tac-Toe game with "Time Travel".
+Build a complete Tic-Tac-Toe game with move history and time travel — entirely in a single HTML file, with no build step. This tutorial is a good introduction to `computed` values and keeping state as an immutable history.
 
 **What you will learn:**
 - Creating reactive state
@@ -186,11 +186,10 @@ const store = state({
 
 ## Step 7: Updating Computed Values
 
-Now that we have history, "current" squares depends on which step we are viewing.
+Now that the board state lives inside `history`, we derive the current squares from the active step number:
 
 ```javascript
-const current = computed(() => store.history[store.stepNumber]);
-const currentSquares = computed(() => current.value.squares);
+const currentSquares = computed(() => store.history[store.stepNumber].squares);
 const winner = computed(() => calculateWinner(currentSquares.value));
 ```
 
@@ -224,20 +223,19 @@ root.addEventListener('click', (e) => {
 Finally, let's render the list of past moves.
 
 ```javascript
-// Helper to jump to a step
+// Jump to any past move
 window.jumpTo = (step) => {
   store.stepNumber = step;
   store.xIsNext = (step % 2) === 0;
 };
 
 effect(() => {
-  // ... render board ...
+  const squares = currentSquares.value;
 
-  // Render History
+  // Build the history button list
   const moves = store.history.map((step, move) => {
     const desc = move ? `Go to move #${move}` : 'Go to game start';
     const isCurrent = move === store.stepNumber;
-    
     return `
       <li>
         <button onclick="jumpTo(${move})" style="${isCurrent ? 'font-weight: bold' : ''}">
@@ -246,8 +244,28 @@ effect(() => {
       </li>
     `;
   }).join('');
-  
-  // Inject into DOM (assuming you added a container for it)
+
+  // Render board + history together
+  root.innerHTML = `
+    <div class="game">
+      <div class="game-board">
+        <div class="status">${winner.value ? 'Winner: ' + winner.value : 'Next player: ' + (store.xIsNext ? 'X' : 'O')}</div>
+        <div class="board">
+          ${[0, 1, 2].map(row => `
+            <div class="board-row">
+              ${[0, 1, 2].map(col => {
+                const i = row * 3 + col;
+                return \`<button class="square" data-index="\${i}">\${squares[i] || ''}</button>\`;
+              }).join('')}
+            </div>
+          `).join('')}
+        </div>
+      </div>
+      <div class="game-info">
+        <ol>${moves}</ol>
+      </div>
+    </div>
+  `;
 });
 ```
 
@@ -385,4 +403,4 @@ effect(() => {
 
 ---
 
-**← Previous: [Working with Arrays](../tutorials/working-with-arrays.md)** | **Next: [API Reference: State](../api/core/state.md) →**
+**← Previous: [Build a Todo app](build-todo-app.md)** | **Next: [Migrating from 1.x](../guides/migration.md) →**

--- a/docs/tutorials/build-todo-app.md
+++ b/docs/tutorials/build-todo-app.md
@@ -1,6 +1,6 @@
 # Tutorial: Build a Todo App
 
-In this tutorial, we will build a fully functional Todo App.
+Build a fully functional todo app — add, toggle, delete, filter, and persist — using nothing but a single HTML file and a CDN import. No build step required.
 
 **What you will learn:**
 - Handling form inputs
@@ -129,41 +129,45 @@ Try adding a few items. They should appear instantly!
 
 ## Step 5: Toggling and Deleting
 
-Now let's make the checkboxes and delete buttons work. We'll add event listeners inside the `render` function of `repeat`.
+Event listeners belong in `create` — it runs once per DOM element, so you won't accidentally attach duplicate listeners on every update.
 
-Update your `render` function:
+Replace your `create` function with this complete version:
 
 ```javascript
-render: (todo, el) => {
-  // ... (previous innerHTML code) ...
+create: (todo, el) => {
+  el.className = 'todo-item';
+  el.innerHTML = `
+    <input type="checkbox" class="toggle">
+    <span class="text"></span>
+    <button class="delete">×</button>
+  `;
 
-  // Handle Toggle
   el.querySelector('.toggle').addEventListener('change', () => {
-    // Immutable update: Map to a new array
-    store.todos = store.todos.map(t => 
+    store.todos = store.todos.map(t =>
       t.id === todo.id ? { ...t, done: !t.done } : t
     );
   });
 
-  // Handle Delete
   el.querySelector('.delete').addEventListener('click', () => {
-    // Immutable update: Filter to a new array
     store.todos = store.todos.filter(t => t.id !== todo.id);
   });
-
-  // ... (previous population code) ...
 }
 ```
+
+Notice the pattern: `create` sets up structure and listeners, `update` (from the previous step) handles data. They don't overlap.
 
 ## Step 6: Computed Filtering
 
 Let's add a feature to show only "Active" or "Completed" items.
 
-First, add a filter to our state:
+First, add a `filter` key to the store. Update your `state()` call to include it:
 
 ```javascript
 const store = state({
-  todos: [...],
+  todos: [
+    { id: 1, text: 'Learn Lume.js', done: false },
+    { id: 2, text: 'Build something cool', done: false }
+  ],
   filter: 'all' // 'all', 'active', 'completed'
 });
 ```
@@ -182,12 +186,13 @@ const visibleTodos = computed(() => {
 });
 ```
 
-Finally, update `repeat` to use `visibleTodos` instead of `store.todos`.
+Finally, update `repeat` to read from `visibleTodos` instead of `store` directly. Computed objects work as stores — just use `'value'` as the key:
 
 ```javascript
-// Change 'store' to 'visibleTodos' (computed objects work like stores!)
-repeat(listContainer, visibleTodos, 'value', { 
-  // ... same options ... 
+repeat(listContainer, visibleTodos, 'value', {
+  key: todo => todo.id,
+  create: (todo, el) => { /* same as before */ },
+  update: (todo, el) => { /* same as before */ }
 });
 ```
 
@@ -337,4 +342,4 @@ Now refresh the page. Your todos are still there!
 
 ---
 
-**Next: [Working with Arrays](../tutorials/working-with-arrays.md) →**
+**← Previous: [stringAttr](../api/handlers/stringAttr.md)** | **Next: [Build Tic-Tac-Toe](build-tic-tac-toe.md) →**


### PR DESCRIPTION
- 9 new guide pages added covering installation, quick-start, core concepts, reactivity, handlers, lists, two-way binding, migration, and FAQ
- 3 new API reference pages for built-in handlers (classToggle, show, stringAttr)
- Richer examples and cross-references across all existing API pages (state, bindDom, effect, watch, computed, repeat, plugins, performance)
- README updated with a structured browser support table and IE11 clarification (Proxy-based, no polyfill path)
- Tutorial pages revised for clarity and accuracy