### PR TITLE
feat: enhance SPA routing, persistent docs layout, and heading anchors

### DIFF
--- a/gh-pages/404.html
+++ b/gh-pages/404.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Lume.js</title>
 <style>
-  /* Brief flash of a loading screen before redirect */
   body { margin: 0; background: #0b0b0c; display: flex; align-items: center; justify-content: center; min-height: 100vh; }
   svg { animation: p 1.2s ease-in-out infinite alternate; }
   @keyframes p { from { opacity: 0.4 } to { opacity: 1 } }
@@ -14,7 +13,7 @@
 <body>
 <!-- GH Pages SPA Fallback
      GitHub Pages serves this file for any unmatched URL.
-     We encode the real path into ?_r=… and redirect to index.html,
+     We encode the app-relative path into ?_r=… and redirect to the app root,
      which reads that param and restores the correct URL via replaceState.
 -->
 <svg width="48" height="48" viewBox="0 0 64 64" fill="none">
@@ -28,15 +27,23 @@
   <path d="M32 18C32 18 24 30 24 40C24 48 28 52 32 54C36 52 40 48 40 40C40 30 32 18 32 18Z" fill="#f5c54a" opacity="0.5"/>
 </svg>
 <script>
-  // Encode current path + search into the _r query param
-  // then redirect to the root index.html
-  var path = location.pathname + location.search + location.hash;
-  // Don't encode if we're already at root (shouldn't happen but guard)
-  if (path === '/' || path === '') {
-    location.replace('/');
+  // For GitHub Pages project pages (e.g. username.github.io/repo/), detect the
+  // base path from the first path segment so the redirect lands on the right root.
+  var isGhPages = /\.(github|gitlab)\.io$/.test(location.hostname);
+  var base = '/';
+  if (isGhPages) {
+    var seg = location.pathname.split('/')[1];
+    if (seg) base = '/' + seg + '/';
+  }
+  var fullPath = location.pathname + location.search + location.hash;
+  // Strip the base prefix so _r carries only the app-relative path.
+  // e.g. /lume-js/docs/intro → _r=/docs/intro  (not /lume-js/docs/intro)
+  var basePfx = base.slice(0, -1); // '/lume-js' (no trailing slash)
+  var appPath = (basePfx && fullPath.startsWith(basePfx)) ? fullPath.slice(basePfx.length) || '/' : fullPath;
+  if (!appPath || appPath === '/') {
+    location.replace(base);
   } else {
-    var encoded = encodeURIComponent(path);
-    location.replace('/?_r=' + encoded);
+    location.replace(base + '?_r=' + encodeURIComponent(appPath));
   }
 </script>
 </body>

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="dark">
+
 <head>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-JMQZGCQ6L9"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+    function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
     gtag('config', 'G-JMQZGCQ6L9');
   </script>
@@ -13,26 +14,34 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Lume.js — Reactivity that follows web standards</title>
-  <meta name="description" content="Minimal reactive state management using only standard JavaScript and HTML. No custom syntax, no build step required." />
-  <meta name="keywords" content="javascript library, reactive, lightweight, no virtual dom, frontend, web development, lume.js, state management" />
+  <meta name="description"
+    content="Minimal reactive state management using only standard JavaScript and HTML. No custom syntax, no build step required." />
+  <meta name="keywords"
+    content="javascript library, reactive, lightweight, no virtual dom, frontend, web development, lume.js, state management" />
   <meta name="author" content="Sathvik C" />
 
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://sathvikc.github.io/lume-js/" />
   <meta property="og:title" content="Lume.js — Reactivity that follows web standards" />
-  <meta property="og:description" content="Minimal reactive state management using only standard JavaScript and HTML. No custom syntax, no build step required." />
+  <meta property="og:description"
+    content="Minimal reactive state management using only standard JavaScript and HTML. No custom syntax, no build step required." />
 
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="https://sathvikc.github.io/lume-js/" />
   <meta property="twitter:title" content="Lume.js — Reactivity that follows web standards" />
-  <meta property="twitter:description" content="Minimal reactive state management using only standard JavaScript and HTML. No custom syntax, no build step required." />
+  <meta property="twitter:description"
+    content="Minimal reactive state management using only standard JavaScript and HTML. No custom syntax, no build step required." />
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,500;9..144,600&display=swap" rel="stylesheet">
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&family=Fraunces:opsz,wght@9..144,300;9..144,400;9..144,500;9..144,600&display=swap"
+    rel="stylesheet">
 
-  <link id="hljs-light" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-light.min.css" disabled>
-  <link id="hljs-dark"  rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
+  <link id="hljs-light" rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-light.min.css" disabled>
+  <link id="hljs-dark" rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 
   <!-- marked v4 — setOptions with highlight callback -->
@@ -40,9 +49,9 @@
 
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
-    (function() {
+    (function () {
       var t = localStorage.getItem('lume.theme');
-      var valid = ['light','dark','dim','solar'];
+      var valid = ['light', 'dark', 'dim', 'solar'];
       if (!t || !valid.includes(t)) t = matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
       document.documentElement.dataset.theme = t;
       var isLight = t === 'light' || t === 'solar';
@@ -65,159 +74,236 @@
 
   <link rel="stylesheet" href="./src/style.css">
 </head>
+
 <body class="bg-bg text-fg font-sans">
 
-<!-- ========================== HEADER ========================== -->
-<header class="site-header sticky top-0 z-30 border-b border-border bg-bg/85 backdrop-blur-md backdrop-saturate-180">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between gap-6">
-    <div class="flex items-center gap-4 relative">
-      <a class="inline-flex items-center gap-2 font-bold text-base tracking-tight" href="/" data-link>
-        <svg width="22" height="22" viewBox="0 0 64 64" fill="none" aria-hidden="true">
-          <defs>
-            <linearGradient id="brandGrad" x1="50%" y1="100%" x2="50%" y2="0%">
-              <stop offset="0%"  stop-color="var(--logo-primary)" />
-              <stop offset="60%" stop-color="var(--logo-secondary)" />
-              <stop offset="100%" stop-color="var(--logo-accent)" />
-            </linearGradient>
-          </defs>
-          <path d="M32 4C32 4 18 22 18 36C18 46 24 54 32 58C40 54 46 46 46 36C46 22 32 4 32 4Z" fill="url(#brandGrad)"/>
-          <path d="M32 18C32 18 24 30 24 40C24 48 28 52 32 54C36 52 40 48 40 40C40 30 32 18 32 18Z" fill="var(--logo-accent)" opacity="0.5"/>
-        </svg>
-        <span class="text-fg">Lume<span class="text-logo-primary">.js</span></span>
-      </a>
-      <nav class="flex items-center gap-6 text-sm" aria-label="Primary" id="primary-nav">
-        <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/"         data-link data-route="home">Home</a>
-        <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/docs"     data-link data-route="docs">Docs</a>
-        <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/examples" data-link data-route="examples">Examples</a>
-        <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/compare"  data-link data-route="compare">Compare</a>
-      </nav>
-    </div>
+  <!-- ========================== HEADER ========================== -->
+  <header class="site-header sticky top-0 z-30 border-b border-border bg-bg/85 backdrop-blur-md backdrop-saturate-180">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between gap-6">
+      <div class="flex items-center gap-4 relative">
+        <a class="inline-flex items-center gap-2 font-bold text-base tracking-tight" href="/" data-link>
+          <svg width="22" height="22" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+            <defs>
+              <linearGradient id="brandGrad" x1="50%" y1="100%" x2="50%" y2="0%">
+                <stop offset="0%" stop-color="var(--logo-primary)" />
+                <stop offset="60%" stop-color="var(--logo-secondary)" />
+                <stop offset="100%" stop-color="var(--logo-accent)" />
+              </linearGradient>
+            </defs>
+            <path d="M32 4C32 4 18 22 18 36C18 46 24 54 32 58C40 54 46 46 46 36C46 22 32 4 32 4Z"
+              fill="url(#brandGrad)" />
+            <path d="M32 18C32 18 24 30 24 40C24 48 28 52 32 54C36 52 40 48 40 40C40 30 32 18 32 18Z"
+              fill="var(--logo-accent)" opacity="0.5" />
+          </svg>
+          <span class="text-fg">Lume<span class="text-logo-primary">.js</span></span>
+        </a>
+        <nav class="flex items-center gap-6 text-sm" aria-label="Primary" id="primary-nav">
+          <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/" data-link data-route="home">Home</a>
+          <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/docs" data-link
+            data-route="docs">Docs</a>
+          <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/examples" data-link
+            data-route="examples">Examples</a>
+          <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/compare" data-link
+            data-route="compare">Compare</a>
+        </nav>
+      </div>
 
-    <div class="flex items-center gap-3">
-      <div style="position:relative">
-        <button class="font-mono text-[10.5px] font-medium text-accent-fg bg-accent-soft px-2 py-1 rounded-md ml-1 border border-accent/30 cursor-pointer inline-flex items-center gap-1 whitespace-nowrap transition-all hover:border-accent"
-                id="ver-btn" title="Version — click to switch" onclick="store.verMenuOpen = !store.verMenuOpen">
-          v2.0.0-beta.1
-          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="opacity-65"><polyline points="6 9 12 15 18 9"/></svg>
-        </button>
-        <div id="ver-menu" inert style="
+      <div class="flex items-center gap-3">
+        <div style="position:relative">
+          <button
+            class="font-mono text-[10.5px] font-medium text-accent-fg bg-accent-soft px-2 py-1 rounded-md ml-1 border border-accent/30 cursor-pointer inline-flex items-center gap-1 whitespace-nowrap transition-all hover:border-accent"
+            id="ver-btn" title="Version — click to switch" onclick="store.verMenuOpen = !store.verMenuOpen">
+            v2.0.0-beta.1
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
+              stroke-linecap="round" stroke-linejoin="round" class="opacity-65">
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+          </button>
+          <div id="ver-menu" inert style="
           position:absolute; right:0; top:calc(100% + 8px); z-index:50;
           background:var(--bg-raised); border:1px solid var(--border);
           border-radius:10px; box-shadow:0 12px 32px rgba(0,0,0,.10),0 2px 6px rgba(0,0,0,.06); padding:6px;
           min-width:220px; opacity:0; transform:translateY(-4px); pointer-events:none;
           transition:opacity .15s, transform .15s;
         ">
-          <div class="px-2.5 pt-2 pb-1 text-[11px] font-semibold text-fg-subtle uppercase tracking-widest font-mono">Version history</div>
-          <button class="theme-option flex items-center gap-2.5 w-full px-2.5 py-2 border-0 bg-transparent text-fg text-left font-inherit text-[13px] rounded-md cursor-pointer hover:bg-bg-sunken justify-between" onclick="store.verMenuOpen=false">
-            <span>v2.0.0-beta.1 <span class="text-[10.5px] text-fg-subtle font-mono">current</span></span>
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--accent-fg)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
-          </button>
-          <button class="theme-option flex items-center gap-2.5 w-full px-2.5 py-2 border-0 bg-transparent text-fg text-left font-inherit text-[13px] rounded-md opacity-45 cursor-not-allowed" disabled>
-            <span>v1.4.2 <span class="text-[10.5px] text-fg-subtle font-mono">stable</span></span>
-          </button>
-          <div class="px-2.5 py-1.5 text-[11.5px] text-fg-subtle border-t border-border mt-1">Multi-version docs coming in stable release.</div>
+            <div class="px-2.5 pt-2 pb-1 text-[11px] font-semibold text-fg-subtle uppercase tracking-widest font-mono">
+              Version history</div>
+            <button
+              class="theme-option flex items-center gap-2.5 w-full px-2.5 py-2 border-0 bg-transparent text-fg text-left font-inherit text-[13px] rounded-md cursor-pointer hover:bg-bg-sunken justify-between"
+              onclick="store.verMenuOpen=false">
+              <span>v2.0.0-beta.1 <span class="text-[10.5px] text-fg-subtle font-mono">current</span></span>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--accent-fg)" stroke-width="2.5"
+                stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            </button>
+            <button
+              class="theme-option flex items-center gap-2.5 w-full px-2.5 py-2 border-0 bg-transparent text-fg text-left font-inherit text-[13px] rounded-md opacity-45 cursor-not-allowed"
+              disabled>
+              <span>v1.4.2 <span class="text-[10.5px] text-fg-subtle font-mono">stable</span></span>
+            </button>
+            <div class="px-2.5 py-1.5 text-[11.5px] text-fg-subtle border-t border-border mt-1">Multi-version docs
+              coming in stable release.</div>
+          </div>
         </div>
-      </div>
-      <div class="theme-picker relative">
-        <button id="theme-btn"
-                class="w-9 h-9 inline-flex items-center justify-center border border-border bg-bg-raised rounded-lg text-fg-muted cursor-pointer transition-all hover:text-fg hover:border-border-strong"
-                aria-label="Change theme"
-                onclick="store.themeMenuOpen = !store.themeMenuOpen">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="9"/>
-            <circle cx="8.5" cy="10" r="1.2" fill="currentColor" stroke="none"/>
-            <circle cx="12" cy="7.5" r="1.2" fill="currentColor" stroke="none"/>
-            <circle cx="15.5" cy="10" r="1.2" fill="currentColor" stroke="none"/>
-            <circle cx="15.5" cy="14" r="1.2" fill="currentColor" stroke="none"/>
-            <path d="M12 21c-1.5 0-2-1-2-2s.5-2 2-2 3-1 3-3"/>
-          </svg>
-        </button>
-        <div id="theme-menu" inert
-             class="theme-menu absolute right-0 top-[calc(100%+8px)] min-w-[240px] bg-bg-raised border border-border rounded-[10px] shadow-xl p-1.5 z-50"
-             role="menu">
-          <div class="px-2.5 pt-2 pb-1 text-[11px] font-semibold text-fg-subtle uppercase tracking-widest font-mono">Theme · <span data-bind="theme"></span></div>
-          <div id="theme-options"></div>
-          <div class="px-2.5 pt-2.5 border-t border-border mt-1 text-[11px] font-semibold text-fg-subtle uppercase tracking-widest font-mono">System</div>
-          <button class="theme-option flex items-center gap-2.5 w-full px-2.5 py-2 border-0 bg-transparent text-fg text-left font-inherit text-[13px] rounded-md cursor-pointer hover:bg-bg-sunken" onclick="resetTheme()">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/></svg>
-            <span>Match system</span>
+        <div class="theme-picker relative">
+          <button id="theme-btn"
+            class="w-9 h-9 inline-flex items-center justify-center border border-border bg-bg-raised rounded-lg text-fg-muted cursor-pointer transition-all hover:text-fg hover:border-border-strong"
+            aria-label="Change theme" onclick="store.themeMenuOpen = !store.themeMenuOpen">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
+              stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="9" />
+              <circle cx="8.5" cy="10" r="1.2" fill="currentColor" stroke="none" />
+              <circle cx="12" cy="7.5" r="1.2" fill="currentColor" stroke="none" />
+              <circle cx="15.5" cy="10" r="1.2" fill="currentColor" stroke="none" />
+              <circle cx="15.5" cy="14" r="1.2" fill="currentColor" stroke="none" />
+              <path d="M12 21c-1.5 0-2-1-2-2s.5-2 2-2 3-1 3-3" />
+            </svg>
           </button>
+          <div id="theme-menu" inert
+            class="theme-menu absolute right-0 top-[calc(100%+8px)] min-w-[240px] bg-bg-raised border border-border rounded-[10px] shadow-xl p-1.5 z-50"
+            role="menu">
+            <div class="px-2.5 pt-2 pb-1 text-[11px] font-semibold text-fg-subtle uppercase tracking-widest font-mono">
+              Theme · <span data-bind="theme"></span></div>
+            <div id="theme-options"></div>
+            <div
+              class="px-2.5 pt-2.5 border-t border-border mt-1 text-[11px] font-semibold text-fg-subtle uppercase tracking-widest font-mono">
+              System</div>
+            <button
+              class="theme-option flex items-center gap-2.5 w-full px-2.5 py-2 border-0 bg-transparent text-fg text-left font-inherit text-[13px] rounded-md cursor-pointer hover:bg-bg-sunken"
+              onclick="resetTheme()">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round">
+                <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+                <path d="M3 3v5h5" />
+              </svg>
+              <span>Match system</span>
+            </button>
+          </div>
         </div>
-      </div>
 
-      <button
-        title="Router mode — click to switch between history and hash routing"
-        onclick="window.switchRouterMode(store.routerMode === 'hash' ? 'history' : 'hash')"
-        class="hidden sm:inline-flex items-center gap-1.5 h-9 px-3 border border-border bg-bg-raised text-fg-muted rounded-lg text-[11.5px] font-mono font-medium cursor-pointer transition-all hover:text-fg hover:border-border-strong whitespace-nowrap">
-        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 16H3m0 0l4-4m-4 4 4 4M3 8h18m0 0-4-4m4 4-4 4"/></svg>
-        <span data-bind="routerMode"></span>
-      </button>
+        <div class="router-mode-wrap hidden sm:block" style="position:relative">
+          <button onclick="window.switchRouterMode(store.routerMode === 'hash' ? 'history' : 'hash')"
+            class="inline-flex items-center gap-1.5 h-9 px-3 border border-border bg-bg-raised text-fg-muted rounded-lg text-[11.5px] font-mono font-medium cursor-pointer transition-all hover:text-fg hover:border-border-strong whitespace-nowrap w-full">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M21 16H3m0 0l4-4m-4 4 4 4M3 8h18m0 0-4-4m4 4-4 4" />
+            </svg>
+            <span data-bind="routerMode"></span>
+          </button>
+          <div class="router-tooltip" role="tooltip">
+            <div class="router-tooltip-mode" data-bind="routerTooltipTitle"></div>
+            <div class="router-tooltip-body" data-bind="routerTooltipBody"></div>
+          </div>
+        </div>
 
-      <a class="inline-flex items-center gap-2 px-3 py-2 text-[13px] font-medium border border-border bg-bg-raised text-fg rounded-lg transition-all hover:border-border-strong hover:bg-bg-sunken"
-         href="https://github.com/sathvikc/lume-js" target="_blank" rel="noopener">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12a12 12 0 008.2 11.4c.6.1.82-.26.82-.58v-2c-3.34.72-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.08 1.84 1.24 1.84 1.24 1.07 1.84 2.8 1.3 3.49 1 .1-.78.42-1.3.76-1.6-2.66-.3-5.47-1.33-5.47-5.92 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.11-3.17 0 0 1-.32 3.3 1.23a11.5 11.5 0 016 0c2.3-1.55 3.3-1.23 3.3-1.23.65 1.65.24 2.87.12 3.17.77.84 1.23 1.91 1.23 3.22 0 4.6-2.8 5.61-5.48 5.91.43.37.82 1.1.82 2.22v3.29c0 .32.22.69.82.57A12 12 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
-        <span>GitHub</span>
-      </a>
-    </div>
-  </div>
-</header>
-
-<!-- ========================== MAIN (SPA outlet) ========================== -->
-<main id="outlet" class="min-h-[60vh]"></main>
-
-<!-- ========================== FOOTER ========================== -->
-<footer class="site-footer border-t border-border pt-12 pb-10 text-fg-muted text-[13.5px]">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6">
-    <div class="grid grid-cols-2 md:grid-cols-[2fr_1fr_1fr_1fr] gap-8 pb-10">
-      <div class="col-span-2 md:col-span-1">
-        <a class="inline-flex items-center gap-2 font-bold text-base" href="/" data-link>
-          <svg width="20" height="20" viewBox="0 0 64 64" fill="none" aria-hidden="true">
-            <defs><linearGradient id="fGrad" x1="50%" y1="100%" x2="50%" y2="0%"><stop offset="0%" stop-color="var(--logo-primary)"/><stop offset="100%" stop-color="var(--logo-accent)"/></linearGradient></defs>
-            <path d="M32 4C32 4 18 22 18 36C18 46 24 54 32 58C40 54 46 46 46 36C46 22 32 4 32 4Z" fill="url(#fGrad)"/>
+        <a class="inline-flex items-center gap-2 px-3 py-2 text-[13px] font-medium border border-border bg-bg-raised text-fg rounded-lg transition-all hover:border-border-strong hover:bg-bg-sunken"
+          href="https://github.com/sathvikc/lume-js" target="_blank" rel="noopener">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path
+              d="M12 0C5.37 0 0 5.37 0 12a12 12 0 008.2 11.4c.6.1.82-.26.82-.58v-2c-3.34.72-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.08 1.84 1.24 1.84 1.24 1.07 1.84 2.8 1.3 3.49 1 .1-.78.42-1.3.76-1.6-2.66-.3-5.47-1.33-5.47-5.92 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.11-3.17 0 0 1-.32 3.3 1.23a11.5 11.5 0 016 0c2.3-1.55 3.3-1.23 3.3-1.23.65 1.65.24 2.87.12 3.17.77.84 1.23 1.91 1.23 3.22 0 4.6-2.8 5.61-5.48 5.91.43.37.82 1.1.82 2.22v3.29c0 .32.22.69.82.57A12 12 0 0024 12c0-6.63-5.37-12-12-12z" />
           </svg>
-          <span class="text-fg">Lume<span class="text-logo-primary">.js</span></span>
+          <span>GitHub</span>
         </a>
-        <p class="mt-3 max-w-xs">Reactivity that follows web standards. MIT-licensed, 2.4&#8239;KB gzipped, zero dependencies.</p>
-        <div class="flex gap-2 mt-4 flex-wrap">
-          <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-mono font-medium border border-border text-fg-muted bg-bg-raised"><span class="w-1.5 h-1.5 rounded-full bg-success animate-pulse-dot"></span> Built with Lume.js</span>
-          <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-mono font-medium border border-border text-fg-muted bg-bg-raised">v2.0.0-beta.1</span>
+      </div>
+    </div>
+  </header>
+
+  <!-- ========================== MAIN (SPA outlet) ========================== -->
+  <main id="outlet" class="min-h-[60vh]"></main>
+
+  <!-- ========================== FOOTER ========================== -->
+  <footer class="site-footer border-t border-border pt-12 pb-10 text-fg-muted text-[13.5px]">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6">
+      <div class="grid grid-cols-2 md:grid-cols-[2fr_1fr_1fr_1fr] gap-8 pb-10">
+        <div class="col-span-2 md:col-span-1">
+          <a class="inline-flex items-center gap-2 font-bold text-base" href="/" data-link>
+            <svg width="20" height="20" viewBox="0 0 64 64" fill="none" aria-hidden="true">
+              <defs>
+                <linearGradient id="fGrad" x1="50%" y1="100%" x2="50%" y2="0%">
+                  <stop offset="0%" stop-color="var(--logo-primary)" />
+                  <stop offset="100%" stop-color="var(--logo-accent)" />
+                </linearGradient>
+              </defs>
+              <path d="M32 4C32 4 18 22 18 36C18 46 24 54 32 58C40 54 46 46 46 36C46 22 32 4 32 4Z"
+                fill="url(#fGrad)" />
+            </svg>
+            <span class="text-fg">Lume<span class="text-logo-primary">.js</span></span>
+          </a>
+          <p class="mt-3 max-w-xs">Reactivity that follows web standards. MIT-licensed, 2.4&#8239;KB gzipped, zero
+            dependencies.</p>
+          <div class="flex gap-2 mt-4 flex-wrap">
+            <span
+              class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-mono font-medium border border-border text-fg-muted bg-bg-raised"><span
+                class="w-1.5 h-1.5 rounded-full bg-success animate-pulse-dot"></span> Built with Lume.js</span>
+            <span
+              class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-mono font-medium border border-border text-fg-muted bg-bg-raised">v2.0.0-beta.1</span>
+          </div>
+        </div>
+        <div>
+          <h6 class="font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest mb-4">Docs</h6>
+          <ul class="list-none p-0 m-0 flex flex-col gap-2">
+            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/introduction"
+                data-link>Introduction</a></li>
+            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/installation"
+                data-link>Installation</a></li>
+            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/core-concepts" data-link>Core
+                concepts</a></li>
+            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/api-state" data-link>API
+                reference</a></li>
+          </ul>
+        </div>
+        <div>
+          <h6 class="font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest mb-4">Community</h6>
+          <ul class="list-none p-0 m-0 flex flex-col gap-2">
+            <li><a class="text-fg-muted hover:text-fg transition-colors" href="https://github.com/sathvikc/lume-js"
+                target="_blank" rel="noopener">GitHub</a></li>
+            <li><a class="text-fg-muted hover:text-fg transition-colors"
+                href="https://github.com/sathvikc/lume-js/issues" target="_blank" rel="noopener">Issues</a></li>
+            <li><a class="text-fg-muted hover:text-fg transition-colors" href="https://www.npmjs.com/package/lume-js"
+                target="_blank" rel="noopener">npm</a></li>
+            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/changelog" data-link>Changelog</a>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h6 class="font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest mb-4">Project</h6>
+          <ul class="list-none p-0 m-0 flex flex-col gap-2">
+            <li><a class="text-fg-muted hover:text-fg transition-colors"
+                href="https://github.com/sathvikc/lume-js/blob/main/LICENSE" target="_blank" rel="noopener">MIT
+                License</a></li>
+            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/migration" data-link>Migrate from
+                1.x</a></li>
+            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/faq" data-link>FAQ</a></li>
+            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/compare" data-link>Compare</a></li>
+          </ul>
         </div>
       </div>
-      <div>
-        <h6 class="font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest mb-4">Docs</h6>
-        <ul class="list-none p-0 m-0 flex flex-col gap-2">
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/introduction" data-link>Introduction</a></li>
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/installation" data-link>Installation</a></li>
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/core-concepts" data-link>Core concepts</a></li>
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/api-state"     data-link>API reference</a></li>
-        </ul>
-      </div>
-      <div>
-        <h6 class="font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest mb-4">Community</h6>
-        <ul class="list-none p-0 m-0 flex flex-col gap-2">
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="https://github.com/sathvikc/lume-js" target="_blank" rel="noopener">GitHub</a></li>
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="https://github.com/sathvikc/lume-js/issues" target="_blank" rel="noopener">Issues</a></li>
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="https://www.npmjs.com/package/lume-js" target="_blank" rel="noopener">npm</a></li>
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/changelog" data-link>Changelog</a></li>
-        </ul>
-      </div>
-      <div>
-        <h6 class="font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest mb-4">Project</h6>
-        <ul class="list-none p-0 m-0 flex flex-col gap-2">
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="https://github.com/sathvikc/lume-js/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a></li>
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/migration" data-link>Migrate from 1.x</a></li>
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/faq"       data-link>FAQ</a></li>
-          <li><a class="text-fg-muted hover:text-fg transition-colors" href="/compare"        data-link>Compare</a></li>
-        </ul>
+      <div class="flex justify-between items-center pt-6 border-t border-border flex-wrap gap-4">
+        <span>© <span data-bind="year"></span> Sathvik C. All rights reserved.</span>
+        <span class="font-mono text-xs">Theme: <span data-bind="theme"></span> · <span data-bind="clock"></span></span>
       </div>
     </div>
-    <div class="flex justify-between items-center pt-6 border-t border-border flex-wrap gap-4">
-      <span>© <span data-bind="year"></span> Sathvik C. All rights reserved.</span>
-      <span class="font-mono text-xs">Theme: <span data-bind="theme"></span> · <span data-bind="clock"></span></span>
-    </div>
-  </div>
-</footer>
+  </footer>
 
-<script type="module" src="./src/app.js"></script>
+  <!-- ========================== TOAST ========================== -->
+  <div id="lume-toast" class="lume-toast" role="alert" aria-live="polite">
+    <div class="toast-hd">
+      <strong class="toast-title" data-bind="toastTitle"></strong>
+      <button class="toast-close" onclick="store.toastVisible = false" aria-label="Dismiss">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
+          stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+    </div>
+    <div class="toast-url" data-bind="toastUrl"></div>
+    <div class="toast-desc" data-bind="toastDesc"></div>
+    <div class="toast-progress" aria-hidden="true"></div>
+  </div>
+
+  <script type="module" src="./src/app.js"></script>
 </body>
+
 </html>

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -209,8 +209,56 @@
     </div>
   </header>
 
-  <!-- ========================== MAIN (SPA outlet) ========================== -->
+  <!-- ========================== MAIN (SPA outlet — non-docs pages) ========================== -->
   <main id="outlet" class="min-h-[60vh]"></main>
+
+  <!-- ========================== DOCS SHELL (persistent — sidebar never re-renders) ========================== -->
+  <div id="docs-shell" hidden>
+
+    <!-- Mobile nav bar -->
+    <div class="lg:hidden sticky top-16 z-20 bg-bg/90 backdrop-blur border-b border-border px-4 py-2.5 flex items-center gap-3">
+      <button id="docs-mobile-toggle"
+              class="inline-flex items-center gap-2 text-[13px] font-medium text-fg-muted border border-border bg-bg-raised rounded-lg px-3 py-1.5 transition-all hover:text-fg hover:border-border-strong">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+        Contents
+      </button>
+      <span id="docs-breadcrumb" class="text-[12px] text-fg-subtle font-mono"></span>
+    </div>
+
+    <!-- Mobile drawer backdrop -->
+    <div id="docs-drawer-backdrop" class="docs-drawer-backdrop fixed inset-0 z-40 bg-[rgba(0,0,0,.45)] backdrop-blur-[2px] hidden lg:hidden"></div>
+
+    <!-- Mobile drawer -->
+    <div id="docs-drawer" class="docs-drawer fixed top-0 left-0 z-50 h-full w-72 max-w-[85vw] bg-bg border-r border-border overflow-y-auto text-[13.5px] p-5 lg:hidden">
+      <div class="flex items-center justify-between mb-4">
+        <span class="font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest">Contents</span>
+        <button id="docs-drawer-close" class="w-8 h-8 inline-flex items-center justify-center rounded-md text-fg-muted hover:text-fg hover:bg-bg-sunken transition-all border-0 bg-transparent cursor-pointer">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
+      </div>
+      <div class="flex items-center gap-2 px-3 py-2 mb-4 bg-bg-raised border border-border rounded-lg">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-fg-subtle shrink-0"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
+        <input id="docs-search-mobile" type="text" placeholder="Filter pages…" autocomplete="off"
+               class="flex-1 border-0 bg-transparent text-fg font-sans text-[13px] outline-none placeholder:text-fg-subtle">
+      </div>
+      <div id="docs-nav-mobile"></div>
+    </div>
+
+    <!-- Main layout grid -->
+    <div class="max-w-[1280px] mx-auto px-4 sm:px-6 grid grid-cols-1 lg:grid-cols-[260px_1fr] xl:grid-cols-[260px_1fr_200px] gap-10 pt-10 pb-20 min-h-[calc(100vh-64px)]">
+      <aside class="docs-sidebar hidden lg:block w-64 shrink-0 sticky top-20 self-start max-h-[calc(100vh-80px)] overflow-y-auto text-[13.5px] pr-2">
+        <div class="flex items-center gap-2 px-3 py-2 mb-4 bg-bg-raised border border-border rounded-lg">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-fg-subtle shrink-0"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
+          <input id="docs-search" type="text" placeholder="Filter pages…" autocomplete="off"
+                 class="flex-1 border-0 bg-transparent text-fg font-sans text-[13px] outline-none placeholder:text-fg-subtle">
+        </div>
+        <nav id="docs-nav"></nav>
+      </aside>
+      <div id="docs-article-outlet" class="min-w-0"></div>
+      <aside class="toc hidden xl:block w-48 shrink-0 sticky top-20 self-start max-h-[calc(100vh-80px)] overflow-y-auto text-[12.5px]" id="toc"></aside>
+    </div>
+
+  </div>
 
   <!-- ========================== FOOTER ========================== -->
   <footer class="site-footer border-t border-border pt-12 pb-10 text-fg-muted text-[13.5px]">

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -170,9 +170,16 @@
           <span class="text-fg">Lume<span class="text-logo-primary">.js</span></span>
         </a>
         <p class="mt-3 max-w-xs">Reactivity that follows web standards. MIT-licensed, 2.4&#8239;KB gzipped, zero dependencies.</p>
-        <div class="flex gap-2 mt-4">
+        <div class="flex gap-2 mt-4 flex-wrap">
           <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-mono font-medium border border-border text-fg-muted bg-bg-raised"><span class="w-1.5 h-1.5 rounded-full bg-success animate-pulse-dot"></span> Built with Lume.js</span>
           <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-mono font-medium border border-border text-fg-muted bg-bg-raised">v2.0.0-beta.1</span>
+          <button
+            title="Toggle between hash and history routing — page reloads into the new mode"
+            onclick="window.switchRouterMode(store.routerMode === 'hash' ? 'history' : 'hash')"
+            class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-mono font-medium border border-border text-fg-muted bg-bg-raised cursor-pointer transition-all hover:border-accent hover:text-accent-fg">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 16H3m0 0l4-4m-4 4 4 4M3 8h18m0 0-4-4m4 4-4 4"/></svg>
+            Router: <span data-bind="routerMode"></span>
+          </button>
         </div>
       </div>
       <div>

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -145,6 +145,14 @@
         </div>
       </div>
 
+      <button
+        title="Router mode — click to switch between history and hash routing"
+        onclick="window.switchRouterMode(store.routerMode === 'hash' ? 'history' : 'hash')"
+        class="hidden sm:inline-flex items-center gap-1.5 h-9 px-3 border border-border bg-bg-raised text-fg-muted rounded-lg text-[11.5px] font-mono font-medium cursor-pointer transition-all hover:text-fg hover:border-border-strong whitespace-nowrap">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 16H3m0 0l4-4m-4 4 4 4M3 8h18m0 0-4-4m4 4-4 4"/></svg>
+        <span data-bind="routerMode"></span>
+      </button>
+
       <a class="inline-flex items-center gap-2 px-3 py-2 text-[13px] font-medium border border-border bg-bg-raised text-fg rounded-lg transition-all hover:border-border-strong hover:bg-bg-sunken"
          href="https://github.com/sathvikc/lume-js" target="_blank" rel="noopener">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0C5.37 0 0 5.37 0 12a12 12 0 008.2 11.4c.6.1.82-.26.82-.58v-2c-3.34.72-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.2.08 1.84 1.24 1.84 1.24 1.07 1.84 2.8 1.3 3.49 1 .1-.78.42-1.3.76-1.6-2.66-.3-5.47-1.33-5.47-5.92 0-1.31.47-2.38 1.24-3.22-.13-.3-.54-1.52.11-3.17 0 0 1-.32 3.3 1.23a11.5 11.5 0 016 0c2.3-1.55 3.3-1.23 3.3-1.23.65 1.65.24 2.87.12 3.17.77.84 1.23 1.91 1.23 3.22 0 4.6-2.8 5.61-5.48 5.91.43.37.82 1.1.82 2.22v3.29c0 .32.22.69.82.57A12 12 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
@@ -173,13 +181,6 @@
         <div class="flex gap-2 mt-4 flex-wrap">
           <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-mono font-medium border border-border text-fg-muted bg-bg-raised"><span class="w-1.5 h-1.5 rounded-full bg-success animate-pulse-dot"></span> Built with Lume.js</span>
           <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-mono font-medium border border-border text-fg-muted bg-bg-raised">v2.0.0-beta.1</span>
-          <button
-            title="Toggle between hash and history routing — page reloads into the new mode"
-            onclick="window.switchRouterMode(store.routerMode === 'hash' ? 'history' : 'hash')"
-            class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11.5px] font-mono font-medium border border-border text-fg-muted bg-bg-raised cursor-pointer transition-all hover:border-accent hover:text-accent-fg">
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 16H3m0 0l4-4m-4 4 4 4M3 8h18m0 0-4-4m4 4-4 4"/></svg>
-            Router: <span data-bind="routerMode"></span>
-          </button>
         </div>
       </div>
       <div>

--- a/gh-pages/src/app.js
+++ b/gh-pages/src/app.js
@@ -51,6 +51,7 @@ const store = state({
   route: { page: 'home', slug: null, params: {} },
   year: new Date().getFullYear(),
   clock: '',
+  routerMode: localStorage.getItem('lume.routerMode') || 'history',
 });
 window.store = store;
 
@@ -222,6 +223,36 @@ const tickClock = () => {
 };
 tickClock();
 setInterval(tickClock, 1000);
+
+/* =========================================================================
+   ROUTER MODE TOGGLE
+   Lets users flip between hash and history routing live — great for seeing
+   how each mode behaves and how Lume.js handles both.
+   Switching saves the preference and reloads to the equivalent URL in the
+   new mode (history→hash: add '#' prefix; hash→history: strip '#', rely on
+   the 404 fallback to redirect back cleanly on GitHub Pages).
+   ========================================================================= */
+window.switchRouterMode = function(newMode) {
+  const base = import.meta.env.BASE_URL;             // '/lume-js/' or '/'
+  const baseNoSlash = base.replace(/\/$/, '');        // '/lume-js'  or ''
+
+  // Current app-relative path regardless of which mode we're in
+  const currentPath = router.mode === 'hash'
+    ? (location.hash || '#/').slice(1)                // '#/docs/foo' → '/docs/foo'
+    : (location.pathname.startsWith(baseNoSlash)
+        ? location.pathname.slice(baseNoSlash.length) || '/'
+        : location.pathname);
+
+  localStorage.setItem('lume.routerMode', newMode);
+
+  if (newMode === 'hash') {
+    // e.g. https://…/lume-js/#/docs/introduction
+    window.location.href = location.origin + base + '#' + currentPath;
+  } else {
+    // e.g. https://…/lume-js/docs/introduction  (GH Pages 404 trick picks it up)
+    window.location.href = location.origin + baseNoSlash + currentPath;
+  }
+};
 
 /* =========================================================================
    GLOBAL BINDINGS (header / footer)

--- a/gh-pages/src/app.js
+++ b/gh-pages/src/app.js
@@ -6,7 +6,7 @@ import { createRouter, link }            from './lume-router.js';
 import { renderHome }                    from './pages/home.js';
 import { renderExamples }                from './pages/examples.js';
 import { renderCompare, renderNotFound } from './pages/compare.js';
-import { renderDocs, wireTOC, fetchDoc, DOCS_SITEMAP } from './pages/docs.js';
+import { renderDocs, wireTOC, wireHeadingAnchors, fetchDoc, DOCS_SITEMAP } from './pages/docs.js';
 
 /* =========================================================================
    MARKED INIT — configure syntax highlighting on the global marked instance
@@ -115,7 +115,22 @@ watch(store, 'route', async (r) => {
 
   if (window.hljs) outlet.querySelectorAll('pre code').forEach(b => hljs.highlightElement(b));
 
-  if (r.page === 'docs') wireTOC();
+  if (r.page === 'docs') {
+    wireTOC();
+    wireHeadingAnchors(router.mode);
+
+    // On initial load (or after a 404 redirect), scroll to a heading if the
+    // URL has a fragment — e.g. /docs/intro#some-section after refresh.
+    const hash = location.hash.slice(1);
+    if (hash) {
+      requestAnimationFrame(() => {
+        const el = document.getElementById(hash);
+        if (!el) return;
+        const top = el.getBoundingClientRect().top + window.scrollY - 80 - 12;
+        window.scrollTo({ top, behavior: 'smooth' });
+      });
+    }
+  }
 }, { immediate: true });
 
 function renderPage(r) {

--- a/gh-pages/src/app.js
+++ b/gh-pages/src/app.js
@@ -1,10 +1,10 @@
 import { state, bindDom, effect } from 'lume-js';
-import { watch }                   from 'lume-js/addons';
+import { watch } from 'lume-js/addons';
 import { classToggle, show, stringAttr } from 'lume-js/handlers';
 
-import { createRouter, link }            from './lume-router.js';
-import { renderHome }                    from './pages/home.js';
-import { renderExamples }                from './pages/examples.js';
+import { createRouter, link } from './lume-router.js';
+import { renderHome } from './pages/home.js';
+import { renderExamples } from './pages/examples.js';
 import { renderCompare, renderNotFound } from './pages/compare.js';
 import { renderDocs, wireTOC, wireHeadingAnchors, fetchDoc, DOCS_SITEMAP } from './pages/docs.js';
 
@@ -31,10 +31,10 @@ if (typeof marked !== 'undefined') {
    THEME REGISTRY
    ========================================================================= */
 const THEMES = [
-  { id: 'light', label: 'Light',     hint: 'Paper',       swatches: ['#fafaf7','#ffffff','#b8541f','#18181b'] },
-  { id: 'dark',  label: 'Dark',      hint: 'Default',     swatches: ['#0b0b0c','#151517','#f5c54a','#f3f1ea'] },
-  { id: 'dim',   label: 'Dim',       hint: 'Tokyo Night', swatches: ['#1a1b26','#1f2030','#7aa2f7','#c0caf5'] },
-  { id: 'solar', label: 'Solarized', hint: 'Warm',        swatches: ['#fdf6e3','#fffaf0','#b8541f','#3a2f1b'] },
+  { id: 'light', label: 'Light', hint: 'Paper', swatches: ['#fafaf7', '#ffffff', '#b8541f', '#18181b'] },
+  { id: 'dark', label: 'Dark', hint: 'Default', swatches: ['#0b0b0c', '#151517', '#f5c54a', '#f3f1ea'] },
+  { id: 'dim', label: 'Dim', hint: 'Tokyo Night', swatches: ['#1a1b26', '#1f2030', '#7aa2f7', '#c0caf5'] },
+  { id: 'solar', label: 'Solarized', hint: 'Warm', swatches: ['#fdf6e3', '#fffaf0', '#b8541f', '#3a2f1b'] },
 ];
 const THEME_IDS = THEMES.map(t => t.id);
 const prefersLight = matchMedia('(prefers-color-scheme: light)').matches;
@@ -44,6 +44,8 @@ const initialTheme = THEME_IDS.includes(saved) ? saved : (prefersLight ? 'light'
 /* =========================================================================
    APP STORE
    ========================================================================= */
+const _initRouterMode = localStorage.getItem('lume.routerMode') || 'history';
+
 const store = state({
   theme: initialTheme,
   themeMenuOpen: false,
@@ -51,7 +53,15 @@ const store = state({
   route: { page: 'home', slug: null, params: {} },
   year: new Date().getFullYear(),
   clock: '',
-  routerMode: localStorage.getItem('lume.routerMode') || 'history',
+  routerMode: _initRouterMode,
+  routerTooltipTitle: _initRouterMode === 'hash' ? 'Hash routing active' : 'History routing active',
+  routerTooltipBody: _initRouterMode === 'hash'
+    ? 'URLs use #/path — works on any static host with no server config.'
+    : 'URLs use /path — clean paths. Needs a server or 404 fallback.',
+  toastVisible: false,
+  toastTitle: '',
+  toastUrl: '',
+  toastDesc: '',
 });
 window.store = store;
 
@@ -69,11 +79,12 @@ watch(demoStore, 'count', (n) => {
    ROUTER
    ========================================================================= */
 const router = createRouter(store, 'route', {
-  '/'            : ()       => ({ page: 'home',     slug: null }),
-  '/docs'        : ()       => ({ page: 'docs',     slug: 'introduction' }),
-  '/docs/:slug'  : (params) => ({ page: 'docs',     slug: params.slug }),
-  '/examples'    : ()       => ({ page: 'examples', slug: null }),
-  '/compare'     : ()       => ({ page: 'compare',  slug: null }),
+  '/': () => ({ page: 'home', slug: null, heading: null }),
+  '/docs': () => ({ page: 'docs', slug: 'introduction', heading: null }),
+  '/docs/:slug': (p) => ({ page: 'docs', slug: p.slug, heading: null }),
+  '/docs/:slug/:heading': (p) => ({ page: 'docs', slug: p.slug, heading: p.heading }),
+  '/examples': () => ({ page: 'examples', slug: null, heading: null }),
+  '/compare': () => ({ page: 'compare', slug: null, heading: null }),
 });
 window.router = router;
 
@@ -82,8 +93,29 @@ window.router = router;
    ========================================================================= */
 const outlet = document.getElementById('outlet');
 let currentCleanup = null;
+let _currentDocSlug = null; // tracks which doc is rendered to detect heading-only nav
+
+function _makeHashHeadingNav(slug) {
+  return (headingId) => router.go(`/docs/${slug}/${headingId}`, { scrollTop: false });
+}
 
 watch(store, 'route', async (r) => {
+  // Hash mode heading-only navigation: same doc, just scroll — no fetch, no re-render
+  if (r.page === 'docs' && r.slug === _currentDocSlug) {
+    const target = r.heading;
+    if (target) {
+      requestAnimationFrame(() => {
+        const el = document.getElementById(target);
+        if (!el) return;
+        const top = el.getBoundingClientRect().top + window.scrollY - 80 - 12;
+        window.scrollTo({ top, behavior: 'smooth' });
+      });
+    }
+    return;
+  }
+
+  _currentDocSlug = r.page === 'docs' ? r.slug : null;
+
   const current = outlet.firstElementChild;
   if (current) current.classList.add('is-leaving');
 
@@ -117,14 +149,13 @@ watch(store, 'route', async (r) => {
 
   if (r.page === 'docs') {
     wireTOC();
-    wireHeadingAnchors(router.mode);
+    wireHeadingAnchors(router.mode, _makeHashHeadingNav(r.slug || 'introduction'));
 
-    // On initial load (or after a 404 redirect), scroll to a heading if the
-    // URL has a fragment — e.g. /docs/intro#some-section after refresh.
-    const hash = location.hash.slice(1);
-    if (hash) {
+    // Scroll to heading if present in route (hash mode deep link) or URL fragment (history mode)
+    const target = r.heading || location.hash.slice(1);
+    if (target) {
       requestAnimationFrame(() => {
-        const el = document.getElementById(hash);
+        const el = document.getElementById(target);
         if (!el) return;
         const top = el.getBoundingClientRect().top + window.scrollY - 80 - 12;
         window.scrollTo({ top, behavior: 'smooth' });
@@ -135,10 +166,10 @@ watch(store, 'route', async (r) => {
 
 function renderPage(r) {
   switch (r.page) {
-    case 'home':     return renderHome();
+    case 'home': return renderHome();
     case 'examples': return renderExamples();
-    case 'compare':  return renderCompare();
-    default:         return renderNotFound();
+    case 'compare': return renderCompare();
+    default: return renderNotFound();
   }
 }
 
@@ -169,9 +200,9 @@ function applyTheme(theme) {
   document.documentElement.dataset.theme = theme;
   const isLight = (theme === 'light' || theme === 'solar');
   const light = document.getElementById('hljs-light');
-  const dark  = document.getElementById('hljs-dark');
+  const dark = document.getElementById('hljs-dark');
   if (light) light.disabled = !isLight;
-  if (dark)  dark.disabled  =  isLight;
+  if (dark) dark.disabled = isLight;
   document.querySelectorAll('.theme-option[data-theme-id]').forEach(btn => {
     btn.classList.toggle('is-current', btn.dataset.themeId === theme);
   });
@@ -247,33 +278,69 @@ setInterval(tickClock, 1000);
    new mode (history→hash: add '#' prefix; hash→history: strip '#', rely on
    the 404 fallback to redirect back cleanly on GitHub Pages).
    ========================================================================= */
-window.switchRouterMode = function(newMode) {
-  const base = import.meta.env.BASE_URL;             // '/lume-js/' or '/'
-  const baseNoSlash = base.replace(/\/$/, '');        // '/lume-js'  or ''
+/* =========================================================================
+   TOAST — Lume.js drives content via data-bind; watch drives visibility
+   ========================================================================= */
+const TOAST_DURATION_MS = 10_000;
+document.documentElement.style.setProperty('--toast-duration', TOAST_DURATION_MS + 'ms');
 
-  // Current app-relative path regardless of which mode we're in
-  const currentPath = router.mode === 'hash'
-    ? (location.hash || '#/').slice(1)                // '#/docs/foo' → '/docs/foo'
-    : (location.pathname.startsWith(baseNoSlash)
-        ? location.pathname.slice(baseNoSlash.length) || '/'
-        : location.pathname);
-
-  localStorage.setItem('lume.routerMode', newMode);
-
-  if (newMode === 'hash') {
-    // e.g. https://…/lume-js/#/docs/introduction
-    window.location.href = location.origin + base + '#' + currentPath;
+let _toastTimer = null;
+watch(store, 'toastVisible', (visible) => {
+  const toast = document.getElementById('lume-toast');
+  if (!toast) return;
+  clearTimeout(_toastTimer);
+  if (visible) {
+    toast.classList.add('is-visible');
+    _toastTimer = setTimeout(() => { store.toastVisible = false; }, TOAST_DURATION_MS);
   } else {
-    // e.g. https://…/lume-js/docs/introduction  (GH Pages 404 trick picks it up)
-    window.location.href = location.origin + baseNoSlash + currentPath;
+    toast.classList.remove('is-visible');
   }
+});
+
+window.switchRouterMode = function (newMode) {
+  const currentRoute = store.route;
+  const historyFragment = newMode === 'hash' ? location.hash.slice(1) : null;
+
+  router.setMode(newMode);
+  store.routerMode = newMode;
+
+  // Rewrite URL to preserve heading in the new mode's encoding
+  const _b = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
+  if (newMode === 'history' && currentRoute.heading) {
+    // hash: #/docs/intro/heading → history: /docs/intro#heading
+    history.replaceState({ lume: true }, '', `${_b}/docs/${currentRoute.slug}#${currentRoute.heading}`);
+  } else if (newMode === 'hash' && historyFragment && currentRoute.page === 'docs') {
+    // history: /docs/intro#heading → hash: #/docs/intro/heading
+    history.replaceState({ lume: true }, '', `${_b}/#/docs/${currentRoute.slug}/${historyFragment}`);
+  }
+
+  document.querySelectorAll('.heading-anchor').forEach(a => a.remove());
+  if (store.route.page === 'docs') {
+    wireHeadingAnchors(newMode, _makeHashHeadingNav(store.route.slug || 'introduction'));
+  }
+
+  store.routerTooltipTitle = newMode === 'hash' ? 'Hash routing active' : 'History routing active';
+  store.routerTooltipBody = newMode === 'hash'
+    ? 'URLs use #/path — works on any static host with no server config.'
+    : 'URLs use /path — clean paths. Needs a server or 404 fallback.';
+
+  store.toastTitle = newMode === 'hash' ? 'Switched to Hash routing' : 'Switched to History routing';
+  store.toastUrl = location.href;
+  store.toastDesc = newMode === 'hash'
+    ? 'Zero server config. Works on any static host. Heading anchors scroll only — # is already the route.'
+    : 'Clean URL paths. A 404 fallback handles deep links — already wired on this site.';
+
+  // Reset animation if toast is already showing, then re-trigger via store
+  store.toastVisible = false;
+  requestAnimationFrame(() => { store.toastVisible = true; });
 };
 
 /* =========================================================================
-   GLOBAL BINDINGS (header / footer)
+   GLOBAL BINDINGS (header / footer / toast)
    ========================================================================= */
 bindDom(document.querySelector('.site-header'), store, { handlers: [link(router)] });
 bindDom(document.querySelector('.site-footer'), store, { handlers: [link(router)] });
+bindDom(document.getElementById('lume-toast'), store, { handlers: [] });
 
 applyTheme(store.theme);
 

--- a/gh-pages/src/app.js
+++ b/gh-pages/src/app.js
@@ -6,7 +6,7 @@ import { createRouter, link } from './lume-router.js';
 import { renderHome } from './pages/home.js';
 import { renderExamples } from './pages/examples.js';
 import { renderCompare, renderNotFound } from './pages/compare.js';
-import { renderDocs, wireTOC, wireHeadingAnchors, fetchDoc, DOCS_SITEMAP } from './pages/docs.js';
+import { renderDocsArticle, mountDocsShell, updateDocsShellForSlug, wireTOC, wireHeadingAnchors, fetchDoc, DOCS_SITEMAP } from './pages/docs.js';
 
 /* =========================================================================
    MARKED INIT — configure syntax highlighting on the global marked instance
@@ -91,9 +91,14 @@ window.router = router;
 /* =========================================================================
    PAGE RENDERING
    ========================================================================= */
-const outlet = document.getElementById('outlet');
-let currentCleanup = null;
-let _currentDocSlug = null; // tracks which doc is rendered to detect heading-only nav
+const outlet      = document.getElementById('outlet');
+const docsShell   = document.getElementById('docs-shell');
+const articleOutlet = document.getElementById('docs-article-outlet');
+
+let currentCleanup    = null;
+let _tocCleanup       = null;
+let _docsShellMounted = false;
+let _currentDocSlug   = null;
 
 function _makeHashHeadingNav(slug) {
   return (headingId) => router.go(`/docs/${slug}/${headingId}`, { scrollTop: false });
@@ -116,42 +121,43 @@ watch(store, 'route', async (r) => {
 
   _currentDocSlug = r.page === 'docs' ? r.slug : null;
 
-  const current = outlet.firstElementChild;
-  if (current) current.classList.add('is-leaving');
-
-  // Fetch doc and run animation in parallel — MD files are small, fetch wins
-  const [docHtml] = await Promise.all([
-    r.page === 'docs' ? fetchDoc(r.slug || 'introduction') : Promise.resolve(null),
-    new Promise(res => setTimeout(res, 120)),
-  ]);
-
-  if (currentCleanup) { currentCleanup(); currentCleanup = null; }
-
-  let html;
   if (r.page === 'docs') {
-    html = renderDocs(r.slug || 'introduction', docHtml);
-  } else {
-    html = renderPage(r);
-  }
+    /* ── docs path: persistent shell, swap article only ── */
+    outlet.hidden    = true;
+    docsShell.hidden = false;
 
-  outlet.innerHTML = `<div class="page">${html}</div>`;
+    // Fade out current article
+    const leaving = articleOutlet.firstElementChild;
+    if (leaving) leaving.classList.add('is-leaving');
 
-  mountPage(r);
+    const slug = r.slug || 'introduction';
+    const [docHtml] = await Promise.all([
+      fetchDoc(slug),
+      new Promise(res => setTimeout(res, 120)),
+    ]);
 
-  currentCleanup = bindDom(outlet, store, {
-    handlers: [show, classToggle('active'), stringAttr('href'), link(router)]
-  });
+    // Mount sidebar + wire drawer/search on first docs visit
+    if (!_docsShellMounted) {
+      mountDocsShell(slug);
+      _docsShellMounted = true;
+    }
 
-  syncNav(r);
-  window.scrollTo({ top: 0, behavior: 'instant' });
+    // Swap article
+    if (_tocCleanup) { _tocCleanup(); _tocCleanup = null; }
+    articleOutlet.innerHTML = `<div class="page">${renderDocsArticle(slug, docHtml)}</div>`;
 
-  if (window.hljs) outlet.querySelectorAll('pre code').forEach(b => hljs.highlightElement(b));
+    // Update active sidebar link + mobile breadcrumb
+    updateDocsShellForSlug(slug);
 
-  if (r.page === 'docs') {
-    wireTOC();
-    wireHeadingAnchors(router.mode, _makeHashHeadingNav(r.slug || 'introduction'));
+    syncNav(r);
+    window.scrollTo({ top: 0, behavior: 'instant' });
 
-    // Scroll to heading if present in route (hash mode deep link) or URL fragment (history mode)
+    if (window.hljs) articleOutlet.querySelectorAll('pre code').forEach(b => hljs.highlightElement(b));
+
+    _tocCleanup = wireTOC();
+    wireHeadingAnchors(router.mode, _makeHashHeadingNav(slug));
+
+    // Scroll to heading if present in route (hash mode) or URL fragment (history mode)
     const target = r.heading || location.hash.slice(1);
     if (target) {
       requestAnimationFrame(() => {
@@ -161,6 +167,29 @@ watch(store, 'route', async (r) => {
         window.scrollTo({ top, behavior: 'smooth' });
       });
     }
+  } else {
+    /* ── non-docs path: use #outlet ── */
+    docsShell.hidden = true;
+    outlet.hidden    = false;
+
+    const current = outlet.firstElementChild;
+    if (current) current.classList.add('is-leaving');
+
+    await new Promise(res => setTimeout(res, 120));
+
+    if (currentCleanup) { currentCleanup(); currentCleanup = null; }
+
+    outlet.innerHTML = `<div class="page">${renderPage(r)}</div>`;
+    mountPage(r);
+
+    currentCleanup = bindDom(outlet, store, {
+      handlers: [show, classToggle('active'), stringAttr('href'), link(router)]
+    });
+
+    syncNav(r);
+    window.scrollTo({ top: 0, behavior: 'instant' });
+
+    if (window.hljs) outlet.querySelectorAll('pre code').forEach(b => hljs.highlightElement(b));
   }
 }, { immediate: true });
 

--- a/gh-pages/src/lume-router.js
+++ b/gh-pages/src/lume-router.js
@@ -2,13 +2,14 @@
  * lume-router — History API + Hash router addon for Lume.js
  *
  * Mode detection (auto):
- *   - GitHub Pages (*.github.io) → hash mode
- *   - Any other host → history mode
+ *   - Checks localStorage('lume.routerMode') first
+ *   - Defaults to 'history' — the 404.html fallback handles GitHub Pages
  *   - Override: createRouter(store, 'route', routes, { mode: 'hash' | 'history' | 'auto' })
  *
- * GH Pages trick:
- *   Ship a 404.html next to index.html that encodes the path into ?_r=…
- *   On init, createRouter detects this and replaces state back to the real path.
+ * GH Pages trick (history mode):
+ *   Ship a 404.html that encodes the app-relative path into ?_r=…
+ *   On init, createRouter detects this, reconstructs the full URL with the
+ *   Vite base path, and replaces state so the URL looks clean.
  *
  * Usage:
  *   import { createRouter, link } from './lume-router.js';
@@ -20,18 +21,17 @@
  *   bindDom(document.body, store, { handlers: [link(router)] });
  */
 
+// Vite replaces this at build time: '/' in dev, '/lume-js/' in production.
+// Stripping the trailing slash gives us a clean prefix to prepend/strip.
+const _BASE = (import.meta.env.BASE_URL || '/').replace(/\/$/, ''); // '' or '/lume-js'
+
 /* ─── mode detection ─── */
 function detectMode() {
   if (typeof window === 'undefined') return 'history';
-  const h = location.hostname;
-  if (
-    h.endsWith('.github.io') ||
-    h.endsWith('.gitlab.io') ||
-    h === 'localhost' && location.port === '' // some static servers
-  ) return 'hash';
-  // Allow explicit opt-in via meta tag: <meta name="lume-router-mode" content="hash">
-  const meta = document.querySelector('meta[name="lume-router-mode"]');
-  if (meta) return meta.content === 'hash' ? 'hash' : 'history';
+  // User's stored preference wins over everything else
+  const stored = localStorage.getItem('lume.routerMode');
+  if (stored === 'hash' || stored === 'history') return stored;
+  // Default: history mode — the 404.html fallback makes it work on GitHub Pages
   return 'history';
 }
 
@@ -45,23 +45,26 @@ function compile(pattern) {
 }
 
 /* ─── GH Pages 404 redirect handler ─── */
-// 404.html encodes the real path into ?_r=<encoded-path>
-// We decode it on startup and replace history so the URL looks clean.
+// 404.html encodes the app-relative path into ?_r=<encoded-path> and redirects
+// to the app root. We decode it and replaceState so the URL looks like a normal
+// navigation — the rest of the router never knows the redirect happened.
 function handleGhPagesRedirect() {
   const params = new URLSearchParams(location.search);
   const redirected = params.get('_r');
   if (!redirected) return;
-  const target = decodeURIComponent(redirected);
-  // Strip _r from the query string and replace state
-  const clean = target || '/';
-  history.replaceState({ lume: true }, '', clean);
+  // _r holds the app-relative path e.g. '/docs/introduction' (without base prefix)
+  const appPath = decodeURIComponent(redirected);
+  // Reconstruct the full URL path including the Vite base
+  const fullPath = _BASE + (appPath.startsWith('/') ? appPath : '/' + appPath);
+  history.replaceState({ lume: true }, '', fullPath);
 }
 
 /* ─── main export ─── */
 export function createRouter(store, key, routes, options = {}) {
   const mode = options.mode === 'auto' || !options.mode ? detectMode() : options.mode;
 
-  handleGhPagesRedirect();
+  // Only restore the redirect in history mode — hash mode never triggers 404.html
+  if (mode === 'history') handleGhPagesRedirect();
 
   const compiled = Object.entries(routes).map(([pattern, resolve]) => ({
     pattern,
@@ -85,7 +88,14 @@ export function createRouter(store, key, routes, options = {}) {
       const h = (location.hash || '#/').slice(1); // '#/docs/foo' → '/docs/foo'
       return h || '/';
     }
-    return location.pathname;
+    // History mode: strip the Vite base prefix before matching routes.
+    // In dev _BASE='' so this is a no-op. In prod _BASE='/lume-js' so
+    // '/lume-js/docs/intro' → '/docs/intro' which matches '/docs/:slug'.
+    const raw = location.pathname;
+    if (_BASE && raw.startsWith(_BASE)) {
+      return raw.slice(_BASE.length) || '/';
+    }
+    return raw;
   }
 
   function read() {
@@ -104,8 +114,12 @@ export function createRouter(store, key, routes, options = {}) {
       if (replace) history.replaceState({ lume: true }, '', newHash);
       else         history.pushState({ lume: true }, '', newHash);
     } else {
-      if (replace) history.replaceState({ lume: true }, '', pathname);
-      else         history.pushState({ lume: true }, '', pathname);
+      // In history mode, prefix the Vite base so the browser URL stays correct.
+      // Routes are always defined without the base (e.g. '/docs/:slug'), but the
+      // actual URL the browser sees must include it (e.g. '/lume-js/docs/intro').
+      const fullPath = _BASE + pathname;
+      if (replace) history.replaceState({ lume: true }, '', fullPath);
+      else         history.pushState({ lume: true }, '', fullPath);
     }
     store[key] = read();
     window.scrollTo({ top: 0, behavior: 'instant' });
@@ -114,7 +128,7 @@ export function createRouter(store, key, routes, options = {}) {
   // Back / forward
   window.addEventListener('popstate', () => { store[key] = read(); });
 
-  // Hash change (hash mode)
+  // Hash change (hash mode only — history mode uses popstate)
   if (mode === 'hash') {
     window.addEventListener('hashchange', () => { store[key] = read(); });
   }
@@ -154,14 +168,15 @@ export function link(router) {
       const url = new URL(href, location.href);
       if (url.origin !== location.origin) return;
 
-      const target = url.pathname + url.search + url.hash;
-
-      // No-op if already on this path (history mode)
+      // No-op if already on this path.
+      // Compare against the app-relative path (routes don't include the base).
       if (router.mode === 'history') {
-        const cur = location.pathname + location.search + location.hash;
-        if (target === cur) return;
+        const rawCur = (_BASE && location.pathname.startsWith(_BASE))
+          ? location.pathname.slice(_BASE.length) || '/'
+          : location.pathname;
+        const curFull = rawCur + location.search + location.hash;
+        if (url.pathname + url.search + url.hash === curFull) return;
       }
-      // No-op if already on this hash (hash mode)
       if (router.mode === 'hash') {
         const curHash = (location.hash || '#/').slice(1);
         if (url.pathname === curHash) return;

--- a/gh-pages/src/lume-router.js
+++ b/gh-pages/src/lume-router.js
@@ -61,7 +61,7 @@ function handleGhPagesRedirect() {
 
 /* ─── main export ─── */
 export function createRouter(store, key, routes, options = {}) {
-  const mode = options.mode === 'auto' || !options.mode ? detectMode() : options.mode;
+  let mode = options.mode === 'auto' || !options.mode ? detectMode() : options.mode;
 
   // Only restore the redirect in history mode — hash mode never triggers 404.html
   if (mode === 'history') handleGhPagesRedirect();
@@ -107,33 +107,64 @@ export function createRouter(store, key, routes, options = {}) {
   /* initial route */
   store[key] = read();
 
-  function go(to, { replace = false } = {}) {
+  function go(to, { replace = false, scrollTop = true } = {}) {
     const pathname = typeof to === 'string' ? to : String(to);
     if (mode === 'hash') {
       const newHash = '#' + pathname;
       if (replace) history.replaceState({ lume: true }, '', newHash);
       else         history.pushState({ lume: true }, '', newHash);
     } else {
-      // In history mode, prefix the Vite base so the browser URL stays correct.
-      // Routes are always defined without the base (e.g. '/docs/:slug'), but the
-      // actual URL the browser sees must include it (e.g. '/lume-js/docs/intro').
       const fullPath = _BASE + pathname;
       if (replace) history.replaceState({ lume: true }, '', fullPath);
       else         history.pushState({ lume: true }, '', fullPath);
     }
     store[key] = read();
-    window.scrollTo({ top: 0, behavior: 'instant' });
+    if (scrollTop) window.scrollTo({ top: 0, behavior: 'instant' });
   }
 
-  // Back / forward
+  // Back / forward (always installed — works in both modes)
   window.addEventListener('popstate', () => { store[key] = read(); });
 
-  // Hash change (hash mode only — history mode uses popstate)
-  if (mode === 'hash') {
-    window.addEventListener('hashchange', () => { store[key] = read(); });
+  // hashchange listener managed separately so setMode can add/remove it
+  const onHashChange = () => { store[key] = read(); };
+  if (mode === 'hash') window.addEventListener('hashchange', onHashChange);
+
+  /**
+   * setMode(newMode) — switch routing mode live without a page reload.
+   *
+   * Rewrites the current URL to the equivalent form in the new mode using
+   * replaceState (no navigation, no server request), swaps the hashchange
+   * listener, and re-reads the route so reactive state stays consistent.
+   *
+   * Callers should also update any mode-dependent UI (e.g. heading anchors).
+   */
+  function setMode(newMode) {
+    if (newMode === mode) return;
+    const currentPath = currentPathname(); // read before switching
+    mode = newMode;
+    localStorage.setItem('lume.routerMode', newMode);
+
+    if (newMode === 'hash') {
+      // Use an absolute path so the hash lands on the app root, not on the
+      // current deep URL (which would give /docs/intro#/docs/intro).
+      history.replaceState({ lume: true }, '', _BASE + '/#' + currentPath);
+      window.addEventListener('hashchange', onHashChange);
+    } else {
+      history.replaceState({ lume: true }, '', _BASE + currentPath);
+      window.removeEventListener('hashchange', onHashChange);
+    }
+
+    store[key] = read();
   }
 
-  return { go, mode, read, matchPathname };
+  // Expose mode as a getter so link() and callers always see the live value
+  return {
+    go,
+    get mode() { return mode; },
+    read,
+    matchPathname,
+    setMode,
+  };
 }
 
 /**

--- a/gh-pages/src/pages/docs.js
+++ b/gh-pages/src/pages/docs.js
@@ -271,3 +271,53 @@ export function wireTOC() {
     });
   }
 }
+
+const LINK_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>`;
+const HEADER_OFFSET = 80;
+
+/**
+ * wireHeadingAnchors(mode) — adds permalink icons to h2/h3 headings.
+ *
+ * Must be called after wireTOC() because wireTOC assigns the heading IDs.
+ *
+ * Behaviour by router mode:
+ *   history — clicking scrolls to the heading, pushes #id to the URL, and
+ *             copies the full link to clipboard. Refresh navigates straight
+ *             to the heading via the 404 fallback.
+ *   hash    — clicking only scrolls. The URL fragment is already used for
+ *             routing (#/docs/slug), so a second fragment isn't possible.
+ *             The anchor icon is still shown so users see the difference.
+ */
+export function wireHeadingAnchors(mode) {
+  const main = document.querySelector('.docs-main');
+  if (!main) return;
+
+  main.querySelectorAll('h2[id], h3[id]').forEach(h => {
+    if (h.querySelector('.heading-anchor')) return; // already wired (no double-add)
+
+    const anchor = document.createElement('a');
+    anchor.className = 'heading-anchor';
+    anchor.href = '#' + h.id;
+    anchor.setAttribute('aria-label', 'Link to this section');
+    if (mode !== 'history') {
+      anchor.title = 'Switch to History routing to get a shareable heading link';
+    }
+    anchor.innerHTML = LINK_ICON;
+
+    anchor.addEventListener('click', (e) => {
+      e.preventDefault();
+      const top = h.getBoundingClientRect().top + window.scrollY - HEADER_OFFSET - 12;
+      window.scrollTo({ top, behavior: 'smooth' });
+
+      if (mode === 'history') {
+        history.pushState({}, '', location.pathname + '#' + h.id);
+        navigator.clipboard?.writeText(location.href).catch(() => {});
+        // Brief visual confirmation
+        anchor.classList.add('is-copied');
+        setTimeout(() => anchor.classList.remove('is-copied'), 1500);
+      }
+    });
+
+    h.appendChild(anchor);
+  });
+}

--- a/gh-pages/src/pages/docs.js
+++ b/gh-pages/src/pages/docs.js
@@ -90,89 +90,60 @@ function renderNotFoundInline() {
   `;
 }
 
-export function renderDocs(slug, html) {
-  const meta = DOCS_SITEMAP.find(d => d.slug === slug);
-  if (!meta || !html) return renderNotFoundInline();
-
+/* ─── sidebar nav HTML (private) ─── */
+function _renderSidebarNav(activeSlug) {
   const groups = {};
   for (const d of DOCS_SITEMAP) {
     (groups[d.category] ||= []).push({ slug: d.slug, title: d.title });
   }
-
-  const sidebar = Object.entries(groups).map(([cat, items]) => `
+  return Object.entries(groups).map(([cat, items]) => `
     <h5 class="font-mono text-[10.5px] font-semibold text-fg-subtle uppercase tracking-widest mt-5 mb-2 px-2 first:mt-0">${cat}</h5>
     <ul class="list-none p-0 m-0">${items.map(it => `
       <li><a href="/docs/${it.slug}" data-link
-             class="block px-3 py-1.5 rounded-md text-fg-muted transition-all hover:text-fg hover:bg-bg-sunken${it.slug === slug ? ' active' : ''}">${it.title}</a></li>
+             class="block px-3 py-1.5 rounded-md text-fg-muted transition-all hover:text-fg hover:bg-bg-sunken${it.slug === activeSlug ? ' active' : ''}">${it.title}</a></li>
     `).join('')}</ul>
   `).join('');
+}
+
+/* ─── article HTML only (swapped on every doc nav) ─── */
+export function renderDocsArticle(slug, html) {
+  const meta = DOCS_SITEMAP.find(d => d.slug === slug);
+  if (!meta || !html) return renderNotFoundInline();
 
   const idx = DOCS_SITEMAP.findIndex(d => d.slug === slug);
   const prev = idx > 0 ? DOCS_SITEMAP[idx - 1] : null;
   const next = idx < DOCS_SITEMAP.length - 1 ? DOCS_SITEMAP[idx + 1] : null;
 
   return `
-    <!-- Mobile nav bar — visible below lg -->
-    <div class="lg:hidden sticky top-16 z-20 bg-bg/90 backdrop-blur border-b border-border px-4 py-2.5 flex items-center gap-3">
-      <button id="docs-mobile-toggle"
-              class="inline-flex items-center gap-2 text-[13px] font-medium text-fg-muted border border-border bg-bg-raised rounded-lg px-3 py-1.5 transition-all hover:text-fg hover:border-border-strong">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
-        Contents
-      </button>
-      <span class="text-[12px] text-fg-subtle font-mono">${meta.category} · ${meta.title}</span>
-    </div>
-
-    <!-- Mobile sidebar drawer -->
-    <div id="docs-drawer-backdrop" class="docs-drawer-backdrop fixed inset-0 z-40 bg-[rgba(0,0,0,.45)] backdrop-blur-[2px] hidden lg:hidden"></div>
-    <div id="docs-drawer" class="docs-drawer fixed top-0 left-0 z-50 h-full w-72 max-w-[85vw] bg-bg border-r border-border overflow-y-auto text-[13.5px] p-5 lg:hidden">
-      <div class="flex items-center justify-between mb-4">
-        <span class="font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest">Contents</span>
-        <button id="docs-drawer-close" class="w-8 h-8 inline-flex items-center justify-center rounded-md text-fg-muted hover:text-fg hover:bg-bg-sunken transition-all border-0 bg-transparent cursor-pointer">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-        </button>
+    <article class="docs-main min-w-0">
+      <div class="crumb">Docs · ${meta.category}</div>
+      ${html}
+      <div class="grid grid-cols-2 gap-4 mt-16 pt-8 border-t border-border">
+        ${prev ? `<a href="/docs/${prev.slug}" data-link class="block p-4 px-5 bg-bg-raised border border-border rounded-[10px] text-fg no-underline transition-all hover:border-accent">
+          <div class="font-mono text-[10.5px] text-fg-subtle uppercase tracking-widest mb-1">← Previous</div>
+          <div class="font-serif font-medium text-lg text-fg">${prev.title}</div>
+        </a>` : '<span></span>'}
+        ${next ? `<a href="/docs/${next.slug}" data-link class="block p-4 px-5 bg-bg-raised border border-border rounded-[10px] text-fg no-underline text-right transition-all hover:border-accent">
+          <div class="font-mono text-[10.5px] text-fg-subtle uppercase tracking-widest mb-1">Next →</div>
+          <div class="font-serif font-medium text-lg text-fg">${next.title}</div>
+        </a>` : '<span></span>'}
       </div>
-      <div class="flex items-center gap-2 px-3 py-2 mb-4 bg-bg-raised border border-border rounded-lg">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-fg-subtle shrink-0"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
-        <input id="docs-search-mobile" type="text" placeholder="Filter pages…" autocomplete="off"
-               class="flex-1 border-0 bg-transparent text-fg font-sans text-[13px] outline-none placeholder:text-fg-subtle">
-      </div>
-      <div id="docs-nav-mobile">${sidebar}</div>
-    </div>
-
-    <div class="max-w-[1280px] mx-auto px-4 sm:px-6 grid grid-cols-1 lg:grid-cols-[260px_1fr] xl:grid-cols-[260px_1fr_200px] gap-10 pt-10 pb-20 min-h-[calc(100vh-64px)]">
-      <aside class="docs-sidebar hidden lg:block w-64 shrink-0 sticky top-20 self-start max-h-[calc(100vh-80px)] overflow-y-auto text-[13.5px] pr-2">
-        <div class="flex items-center gap-2 px-3 py-2 mb-4 bg-bg-raised border border-border rounded-lg">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-fg-subtle shrink-0"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
-          <input id="docs-search" type="text" placeholder="Filter pages…" autocomplete="off"
-                 class="flex-1 border-0 bg-transparent text-fg font-sans text-[13px] outline-none placeholder:text-fg-subtle">
-        </div>
-        <div id="docs-nav">${sidebar}</div>
-      </aside>
-      <article class="docs-main min-w-0">
-        <div class="crumb">Docs · ${meta.category}</div>
-        ${html}
-        <div class="grid grid-cols-2 gap-4 mt-16 pt-8 border-t border-border">
-          ${prev ? `<a href="/docs/${prev.slug}" data-link class="block p-4 px-5 bg-bg-raised border border-border rounded-[10px] text-fg no-underline transition-all hover:border-accent">
-            <div class="font-mono text-[10.5px] text-fg-subtle uppercase tracking-widest mb-1">← Previous</div>
-            <div class="font-serif font-medium text-lg text-fg">${prev.title}</div>
-          </a>` : '<span></span>'}
-          ${next ? `<a href="/docs/${next.slug}" data-link class="block p-4 px-5 bg-bg-raised border border-border rounded-[10px] text-fg no-underline text-right transition-all hover:border-accent">
-            <div class="font-mono text-[10.5px] text-fg-subtle uppercase tracking-widest mb-1">Next →</div>
-            <div class="font-serif font-medium text-lg text-fg">${next.title}</div>
-          </a>` : '<span></span>'}
-        </div>
-      </article>
-      <aside class="toc hidden xl:block w-48 shrink-0 sticky top-20 self-start max-h-[calc(100vh-80px)] overflow-y-auto text-[12.5px]" id="toc"></aside>
-    </div>
+    </article>
   `;
 }
 
-export function wireTOC() {
-  // Mobile drawer wiring
-  const toggleBtn  = document.getElementById('docs-mobile-toggle');
-  const backdrop   = document.getElementById('docs-drawer-backdrop');
-  const drawer     = document.getElementById('docs-drawer');
-  const closeBtn   = document.getElementById('docs-drawer-close');
+/* ─── mount docs shell — populate sidebar nav and wire drawer/search (called once) ─── */
+export function mountDocsShell(slug) {
+  const navHtml = _renderSidebarNav(slug);
+  const navEl       = document.getElementById('docs-nav');
+  const navMobileEl = document.getElementById('docs-nav-mobile');
+  if (navEl)       navEl.innerHTML       = navHtml;
+  if (navMobileEl) navMobileEl.innerHTML = navHtml;
+
+  const toggleBtn   = document.getElementById('docs-mobile-toggle');
+  const backdrop    = document.getElementById('docs-drawer-backdrop');
+  const drawer      = document.getElementById('docs-drawer');
+  const closeBtn    = document.getElementById('docs-drawer-close');
   const mobileSearch = document.getElementById('docs-search-mobile');
 
   function openDrawer()  { drawer?.classList.add('is-open'); backdrop?.classList.remove('hidden'); document.body.style.overflow = 'hidden'; }
@@ -181,23 +152,42 @@ export function wireTOC() {
   toggleBtn?.addEventListener('click', openDrawer);
   closeBtn?.addEventListener('click', closeDrawer);
   backdrop?.addEventListener('click', closeDrawer);
-  drawer?.querySelectorAll('a[data-link]').forEach(a => a.addEventListener('click', closeDrawer));
+  navMobileEl?.querySelectorAll('a[data-link]').forEach(a => a.addEventListener('click', closeDrawer));
 
-  if (mobileSearch) {
-    mobileSearch.addEventListener('input', () => {
-      const q = mobileSearch.value.trim().toLowerCase();
-      document.querySelectorAll('#docs-nav-mobile li').forEach(li => {
-        li.style.display = !q || li.textContent.toLowerCase().includes(q) ? '' : 'none';
-      });
+  mobileSearch?.addEventListener('input', () => {
+    const q = mobileSearch.value.trim().toLowerCase();
+    navMobileEl?.querySelectorAll('li').forEach(li => {
+      li.style.display = !q || li.textContent.toLowerCase().includes(q) ? '' : 'none';
     });
-  }
+  });
 
+  const desktopSearch = document.getElementById('docs-search');
+  desktopSearch?.addEventListener('input', () => {
+    const q = desktopSearch.value.trim().toLowerCase();
+    navEl?.querySelectorAll('li').forEach(li => {
+      li.style.display = !q || li.textContent.toLowerCase().includes(q) ? '' : 'none';
+    });
+  });
+}
+
+/* ─── update active sidebar link + breadcrumb (called on every doc nav) ─── */
+export function updateDocsShellForSlug(slug) {
+  const meta = DOCS_SITEMAP.find(d => d.slug === slug);
+  document.querySelectorAll('#docs-nav a, #docs-nav-mobile a').forEach(a => {
+    a.classList.toggle('active', a.getAttribute('href') === `/docs/${slug}`);
+  });
+  const crumb = document.getElementById('docs-breadcrumb');
+  if (crumb && meta) crumb.textContent = `${meta.category} · ${meta.title}`;
+}
+
+/* ─── wire TOC observers — returns cleanup, called after every article swap ─── */
+export function wireTOC() {
   const main = document.querySelector('.docs-main');
   const toc  = document.getElementById('toc');
-  if (!main || !toc) return;
+  if (!main || !toc) return () => {};
 
   const headings = main.querySelectorAll('h2, h3');
-  if (!headings.length) { toc.innerHTML = ''; return; }
+  if (!headings.length) { toc.innerHTML = ''; return () => {}; }
 
   const items = [...headings].map((h, i) => {
     const id = h.id || `h-${i}-${h.textContent.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 40)}`;
@@ -232,16 +222,17 @@ export function wireTOC() {
 
   headingEls.forEach(el => io.observe(el));
 
-  window.addEventListener('scroll', () => {
+  const onScroll = () => {
     const scrollY = window.scrollY + HEADER_H + 16;
     let best = headingEls[0];
     for (const el of headingEls) {
       if (el.offsetTop <= scrollY) best = el;
     }
     if (best) updateActiveTOC(best.id);
-  }, { passive: true });
+  };
+  window.addEventListener('scroll', onScroll, { passive: true });
 
-  // Set initial active heading based on current scroll position
+  // Set initial active heading based on current scroll
   {
     const scrollY = window.scrollY + HEADER_H + 16;
     let best = headingEls[0];
@@ -261,38 +252,12 @@ export function wireTOC() {
     });
   });
 
-  const search = document.getElementById('docs-search');
-  if (search) {
-    search.addEventListener('input', () => {
-      const q = search.value.trim().toLowerCase();
-      document.querySelectorAll('#docs-nav li').forEach(li => {
-        li.style.display = !q || li.textContent.toLowerCase().includes(q) ? '' : 'none';
-      });
-    });
-  }
+  return () => { io.disconnect(); window.removeEventListener('scroll', onScroll); };
 }
 
 const LINK_ICON = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>`;
 const HEADER_OFFSET = 80;
 
-/**
- * wireHeadingAnchors(mode) — adds permalink icons to h2/h3 headings.
- *
- * Must be called after wireTOC() because wireTOC assigns the heading IDs.
- *
- * Behaviour by router mode:
- *   history — clicking scrolls to the heading, pushes #id to the URL, and
- *             copies the full link to clipboard. Refresh navigates straight
- *             to the heading via the 404 fallback.
- *   hash    — clicking only scrolls. The URL fragment is already used for
- *             routing (#/docs/slug), so a second fragment isn't possible.
- *             The anchor icon is still shown so users see the difference.
- */
-/**
- * onHashHeadingNav(headingId) — called in hash mode when an anchor is clicked.
- * Navigates to /docs/:slug/:heading via the router (no scroll-to-top, no re-render
- * for same-slug pages). URL becomes e.g. #/docs/introduction/what-is-lume-js.
- */
 export function wireHeadingAnchors(mode, onHashHeadingNav) {
   const main = document.querySelector('.docs-main');
   if (!main) return;
@@ -308,7 +273,6 @@ export function wireHeadingAnchors(mode, onHashHeadingNav) {
     if (mode === 'history') {
       anchor.href = '#' + h.id;
     } else {
-      // In hash mode the href is cosmetic — click is fully handled below
       anchor.href = 'javascript:void(0)';
     }
 
@@ -323,9 +287,7 @@ export function wireHeadingAnchors(mode, onHashHeadingNav) {
         anchor.classList.add('is-copied');
         setTimeout(() => anchor.classList.remove('is-copied'), 1500);
       } else if (onHashHeadingNav) {
-        // Navigate via router (updates hash URL, route watcher scrolls without re-render)
         onHashHeadingNav(h.id);
-        // router.go() is synchronous — location.href is the new URL now
         navigator.clipboard?.writeText(location.href).catch(() => {});
         anchor.classList.add('is-copied');
         setTimeout(() => anchor.classList.remove('is-copied'), 1500);

--- a/gh-pages/src/pages/docs.js
+++ b/gh-pages/src/pages/docs.js
@@ -288,31 +288,45 @@ const HEADER_OFFSET = 80;
  *             routing (#/docs/slug), so a second fragment isn't possible.
  *             The anchor icon is still shown so users see the difference.
  */
-export function wireHeadingAnchors(mode) {
+/**
+ * onHashHeadingNav(headingId) — called in hash mode when an anchor is clicked.
+ * Navigates to /docs/:slug/:heading via the router (no scroll-to-top, no re-render
+ * for same-slug pages). URL becomes e.g. #/docs/introduction/what-is-lume-js.
+ */
+export function wireHeadingAnchors(mode, onHashHeadingNav) {
   const main = document.querySelector('.docs-main');
   if (!main) return;
 
   main.querySelectorAll('h2[id], h3[id]').forEach(h => {
-    if (h.querySelector('.heading-anchor')) return; // already wired (no double-add)
+    if (h.querySelector('.heading-anchor')) return;
 
     const anchor = document.createElement('a');
     anchor.className = 'heading-anchor';
-    anchor.href = '#' + h.id;
     anchor.setAttribute('aria-label', 'Link to this section');
-    if (mode !== 'history') {
-      anchor.title = 'Switch to History routing to get a shareable heading link';
-    }
     anchor.innerHTML = LINK_ICON;
+
+    if (mode === 'history') {
+      anchor.href = '#' + h.id;
+    } else {
+      // In hash mode the href is cosmetic — click is fully handled below
+      anchor.href = 'javascript:void(0)';
+    }
 
     anchor.addEventListener('click', (e) => {
       e.preventDefault();
-      const top = h.getBoundingClientRect().top + window.scrollY - HEADER_OFFSET - 12;
-      window.scrollTo({ top, behavior: 'smooth' });
 
       if (mode === 'history') {
+        const top = h.getBoundingClientRect().top + window.scrollY - HEADER_OFFSET - 12;
+        window.scrollTo({ top, behavior: 'smooth' });
         history.pushState({}, '', location.pathname + '#' + h.id);
         navigator.clipboard?.writeText(location.href).catch(() => {});
-        // Brief visual confirmation
+        anchor.classList.add('is-copied');
+        setTimeout(() => anchor.classList.remove('is-copied'), 1500);
+      } else if (onHashHeadingNav) {
+        // Navigate via router (updates hash URL, route watcher scrolls without re-render)
+        onHashHeadingNav(h.id);
+        // router.go() is synchronous — location.href is the new URL now
+        navigator.clipboard?.writeText(location.href).catch(() => {});
         anchor.classList.add('is-copied');
         setTimeout(() => anchor.classList.remove('is-copied'), 1500);
       }

--- a/gh-pages/src/style.css
+++ b/gh-pages/src/style.css
@@ -295,4 +295,28 @@ code, kbd, pre { font-family: var(--font-family-mono); }
 .docs-main a:hover { text-decoration-color: var(--accent); }
 .docs-main .small { font-size: 13px; color: var(--fg-subtle); }
 
+/* ─── Heading anchor links (section permalinks) ─── */
+/* Inline link icon appended after heading text; revealed on hover.
+   In history mode: clicking pushes #id to the URL and copies the link.
+   In hash mode: clicking only scrolls (the fragment is used for routing). */
+.heading-anchor {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.45rem;
+  color: var(--fg-subtle);
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+  text-decoration: none;
+  vertical-align: middle;
+}
+.docs-main h2:hover .heading-anchor,
+.docs-main h3:hover .heading-anchor {
+  opacity: 1;
+}
+.heading-anchor:hover,
+.heading-anchor.is-copied {
+  color: var(--accent-fg);
+  opacity: 1;
+}
+
 [hidden] { display: none !important; }

--- a/gh-pages/src/style.css
+++ b/gh-pages/src/style.css
@@ -9,65 +9,115 @@
   --font-family-serif: "Fraunces", ui-serif, Georgia, serif;
 
   /* Semantic color tokens — resolved at runtime from per-theme CSS vars */
-  --color-bg:              var(--bg);
-  --color-bg-raised:       var(--bg-raised);
-  --color-bg-sunken:       var(--bg-sunken);
-  --color-bg-code:         var(--bg-code);
-  --color-fg:              var(--fg);
-  --color-fg-muted:        var(--fg-muted);
-  --color-fg-subtle:       var(--fg-subtle);
-  --color-border:          var(--border);
-  --color-border-strong:   var(--border-strong);
-  --color-accent:          var(--accent);
-  --color-accent-soft:     var(--accent-soft);
-  --color-accent-fg:       var(--accent-fg);
+  --color-bg: var(--bg);
+  --color-bg-raised: var(--bg-raised);
+  --color-bg-sunken: var(--bg-sunken);
+  --color-bg-code: var(--bg-code);
+  --color-fg: var(--fg);
+  --color-fg-muted: var(--fg-muted);
+  --color-fg-subtle: var(--fg-subtle);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-accent: var(--accent);
+  --color-accent-soft: var(--accent-soft);
+  --color-accent-fg: var(--accent-fg);
   --color-accent-contrast: var(--accent-contrast);
-  --color-success:         var(--success);
-  --color-logo-primary:    var(--logo-primary);
-  --color-logo-secondary:  var(--logo-secondary);
-  --color-logo-accent:     var(--logo-accent);
+  --color-success: var(--success);
+  --color-logo-primary: var(--logo-primary);
+  --color-logo-secondary: var(--logo-secondary);
+  --color-logo-accent: var(--logo-accent);
 }
 
 /* ─── Theme definitions ─── */
 [data-theme="light"] {
-  --bg: #fafaf7; --bg-sunken: #f3f2ec; --bg-raised: #ffffff; --bg-code: #faf8f3;
-  --fg: #18181b; --fg-muted: #52525b; --fg-subtle: #8a8a93;
-  --border: #e7e5de; --border-strong: #d6d3ca;
-  --accent: #b8541f; --accent-soft: #f6e3d3; --accent-fg: #8a3e14; --accent-contrast: #ffffff;
+  --bg: #fafaf7;
+  --bg-sunken: #f3f2ec;
+  --bg-raised: #ffffff;
+  --bg-code: #faf8f3;
+  --fg: #18181b;
+  --fg-muted: #52525b;
+  --fg-subtle: #8a8a93;
+  --border: #e7e5de;
+  --border-strong: #d6d3ca;
+  --accent: #b8541f;
+  --accent-soft: #f6e3d3;
+  --accent-fg: #8a3e14;
+  --accent-contrast: #ffffff;
   --success: #2f7d4a;
-  --logo-primary: #b8541f; --logo-secondary: #d97757; --logo-accent: #f5c54a;
+  --logo-primary: #b8541f;
+  --logo-secondary: #d97757;
+  --logo-accent: #f5c54a;
   color-scheme: light;
 }
+
 [data-theme="dark"] {
-  --bg: #0b0b0c; --bg-sunken: #0f0f11; --bg-raised: #151517; --bg-code: #0f0f11;
-  --fg: #f3f1ea; --fg-muted: #a3a098; --fg-subtle: #6a685f;
-  --border: #232327; --border-strong: #33333a;
-  --accent: #f5c54a; --accent-soft: #2a220e; --accent-fg: #f5c54a; --accent-contrast: #111113;
+  --bg: #0b0b0c;
+  --bg-sunken: #0f0f11;
+  --bg-raised: #151517;
+  --bg-code: #0f0f11;
+  --fg: #f3f1ea;
+  --fg-muted: #a3a098;
+  --fg-subtle: #6a685f;
+  --border: #232327;
+  --border-strong: #33333a;
+  --accent: #f5c54a;
+  --accent-soft: #2a220e;
+  --accent-fg: #f5c54a;
+  --accent-contrast: #111113;
   --success: #66c28b;
-  --logo-primary: #ff8f6b; --logo-secondary: #f5c54a; --logo-accent: #ffd97a;
+  --logo-primary: #ff8f6b;
+  --logo-secondary: #f5c54a;
+  --logo-accent: #ffd97a;
   color-scheme: dark;
 }
+
 [data-theme="dim"] {
-  --bg: #1a1b26; --bg-sunken: #16171f; --bg-raised: #1f2030; --bg-code: #16171f;
-  --fg: #c0caf5; --fg-muted: #8a93bd; --fg-subtle: #565f89;
-  --border: #2a2b3d; --border-strong: #3b3d57;
-  --accent: #7aa2f7; --accent-soft: #1c2239; --accent-fg: #9db4ff; --accent-contrast: #0f1019;
+  --bg: #1a1b26;
+  --bg-sunken: #16171f;
+  --bg-raised: #1f2030;
+  --bg-code: #16171f;
+  --fg: #c0caf5;
+  --fg-muted: #8a93bd;
+  --fg-subtle: #565f89;
+  --border: #2a2b3d;
+  --border-strong: #3b3d57;
+  --accent: #7aa2f7;
+  --accent-soft: #1c2239;
+  --accent-fg: #9db4ff;
+  --accent-contrast: #0f1019;
   --success: #9ece6a;
-  --logo-primary: #bb9af7; --logo-secondary: #7aa2f7; --logo-accent: #7dcfff;
+  --logo-primary: #bb9af7;
+  --logo-secondary: #7aa2f7;
+  --logo-accent: #7dcfff;
   color-scheme: dark;
 }
+
 [data-theme="solar"] {
-  --bg: #fdf6e3; --bg-sunken: #f4ecd6; --bg-raised: #fffaf0; --bg-code: #f4ecd6;
-  --fg: #3a2f1b; --fg-muted: #6b5d42; --fg-subtle: #93876a;
-  --border: #e5d9b6; --border-strong: #cab88a;
-  --accent: #b8541f; --accent-soft: #f1d9bc; --accent-fg: #8a3e14; --accent-contrast: #fffaf0;
+  --bg: #fdf6e3;
+  --bg-sunken: #f4ecd6;
+  --bg-raised: #fffaf0;
+  --bg-code: #f4ecd6;
+  --fg: #3a2f1b;
+  --fg-muted: #6b5d42;
+  --fg-subtle: #93876a;
+  --border: #e5d9b6;
+  --border-strong: #cab88a;
+  --accent: #b8541f;
+  --accent-soft: #f1d9bc;
+  --accent-fg: #8a3e14;
+  --accent-contrast: #fffaf0;
   --success: #557d2e;
-  --logo-primary: #b8541f; --logo-secondary: #cb4b16; --logo-accent: #d97757;
+  --logo-primary: #b8541f;
+  --logo-secondary: #cb4b16;
+  --logo-accent: #d97757;
   color-scheme: light;
 }
 
 /* ─── Base ─── */
-html { background: var(--bg); }
+html {
+  background: var(--bg);
+}
+
 body {
   font-family: var(--font-family-sans);
   color: var(--fg);
@@ -78,9 +128,22 @@ body {
   text-rendering: optimizeLegibility;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
-a { color: inherit; text-decoration: none; }
-code, kbd, pre { font-family: var(--font-family-mono); }
-::selection { background: var(--accent-soft); color: var(--accent-fg); }
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+code,
+kbd,
+pre {
+  font-family: var(--font-family-mono);
+}
+
+::selection {
+  background: var(--accent-soft);
+  color: var(--accent-fg);
+}
 
 /* ─── Hero glow (radial gradient animation — not doable in Tailwind) ─── */
 .hero-glow {
@@ -96,31 +159,59 @@ code, kbd, pre { font-family: var(--font-family-mono); }
 
 /* ─── Pulse animation ─── */
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.55; }
+
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.55;
+  }
 }
-.animate-pulse-dot { animation: pulse 2.4s ease-in-out infinite; }
+
+.animate-pulse-dot {
+  animation: pulse 2.4s ease-in-out infinite;
+}
 
 /* ─── Page enter animation ─── */
 @keyframes page-enter {
-  from { opacity: 0; transform: translateY(6px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
-.page-enter { animation: page-enter 0.22s ease both; }
+
+.page-enter {
+  animation: page-enter 0.22s ease both;
+}
 
 /* ─── SPA page transitions ─── */
-.page { opacity: 1; transition: opacity 0.18s ease; }
-.page.is-leaving { opacity: 0; }
+.page {
+  opacity: 1;
+  transition: opacity 0.18s ease;
+}
+
+.page.is-leaving {
+  opacity: 0;
+}
 
 /* ─── Nav active underline ─── */
 #primary-nav a.active {
   color: var(--accent-fg);
   position: relative;
 }
+
 #primary-nav a.active::after {
   content: "";
   position: absolute;
-  left: 0; right: 0;
+  left: 0;
+  right: 0;
   bottom: -1px;
   height: 2px;
   background: var(--accent);
@@ -134,6 +225,7 @@ code, kbd, pre { font-family: var(--font-family-mono); }
   pointer-events: none;
   transition: opacity 0.15s, transform 0.15s;
 }
+
 .theme-menu.is-open {
   opacity: 1;
   transform: translateY(0);
@@ -141,15 +233,32 @@ code, kbd, pre { font-family: var(--font-family-mono); }
 }
 
 /* ─── Theme option current ─── */
-.theme-option .check { opacity: 0; }
-.theme-option.is-current { color: var(--accent-fg); }
-.theme-option.is-current .check { opacity: 1; }
+.theme-option .check {
+  opacity: 0;
+}
+
+.theme-option.is-current {
+  color: var(--accent-fg);
+}
+
+.theme-option.is-current .check {
+  opacity: 1;
+}
 
 /* ─── Mobile docs drawer ─── */
 /* Tailwind v4 uses the CSS `translate` property, so we must match it here */
-.docs-drawer { translate: -100% 0; transition: translate 0.25s cubic-bezier(0.4, 0, 0.2, 1); }
-.docs-drawer.is-open { translate: 0 0; }
-.docs-drawer-backdrop { transition: opacity 0.25s ease; }
+.docs-drawer {
+  translate: -100% 0;
+  transition: translate 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.docs-drawer.is-open {
+  translate: 0 0;
+}
+
+.docs-drawer-backdrop {
+  transition: opacity 0.25s ease;
+}
 
 /* ─── Docs sidebar active link ─── */
 /* Uses inset box-shadow instead of border-left so the indicator respects border-radius
@@ -173,7 +282,9 @@ code, kbd, pre { font-family: var(--font-family-mono); }
 /* Fix Tailwind's two-hop CSS variable chain for accent-contrast text.
    --color-accent-contrast → var(--accent-contrast) can mis-resolve across layers,
    causing text to inherit the body colour instead. This shortcut wins. */
-.text-accent-contrast { color: var(--accent-contrast) !important; }
+.text-accent-contrast {
+  color: var(--accent-contrast) !important;
+}
 
 /* ─── TOC active link ─── */
 .toc a.is-current {
@@ -183,13 +294,21 @@ code, kbd, pre { font-family: var(--font-family-mono); }
 }
 
 /* ─── Code block (hljs) overrides ─── */
-.hljs { background: transparent !important; padding: 0 !important; }
+.hljs {
+  background: transparent !important;
+  padding: 0 !important;
+}
 
 /* ─── Highlight.js theme toggling ─── */
 [data-theme="light"] #hljs-dark,
-[data-theme="solar"] #hljs-dark { display: none; }
-[data-theme="dark"]  #hljs-light,
-[data-theme="dim"]   #hljs-light { display: none; }
+[data-theme="solar"] #hljs-dark {
+  display: none;
+}
+
+[data-theme="dark"] #hljs-light,
+[data-theme="dim"] #hljs-light {
+  display: none;
+}
 
 /* ─── Compare table lume column highlight ─── */
 .lume-col {
@@ -213,13 +332,16 @@ code, kbd, pre { font-family: var(--font-family-mono); }
   pointer-events: none;
   transition: opacity 0.18s ease;
 }
+
 #search-backdrop.is-open {
   opacity: 1;
   pointer-events: auto;
 }
+
 #search-backdrop.is-open #search-box {
   transform: translateY(0) scale(1);
 }
+
 #search-box {
   transform: translateY(-8px) scale(0.98);
   transition: transform 0.18s ease;
@@ -253,47 +375,251 @@ code, kbd, pre { font-family: var(--font-family-mono); }
 }
 
 /* ─── doc-table ─── */
-.doc-table { width: 100%; border-collapse: collapse; margin: 16px 0 24px; font-size: 13.5px; }
-.doc-table th, .doc-table td { padding: 10px 14px; text-align: left; border-bottom: 1px solid var(--border); vertical-align: top; }
-.doc-table thead th { font-family: var(--font-family-mono); font-size: 10.5px; font-weight: 600; color: var(--fg-subtle); text-transform: uppercase; letter-spacing: 0.08em; background: var(--bg-sunken); }
+.doc-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0 24px;
+  font-size: 13.5px;
+}
+
+.doc-table th,
+.doc-table td {
+  padding: 10px 14px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.doc-table thead th {
+  font-family: var(--font-family-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--fg-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: var(--bg-sunken);
+}
 
 /* ─── Markdown-rendered tables inside docs prose ─── */
-.docs-main table { width: 100%; border-collapse: collapse; margin: 16px 0 24px; font-size: 13.5px; display: table; }
-.docs-main th, .docs-main td { padding: 10px 14px; text-align: left; border: 1px solid var(--border); vertical-align: top; color: var(--fg-muted); }
-.docs-main thead th { font-family: var(--font-family-mono); font-size: 10.5px; font-weight: 600; color: var(--fg-subtle); text-transform: uppercase; letter-spacing: 0.08em; background: var(--bg-sunken); border-color: var(--border); }
-.docs-main tbody tr:hover td { background: var(--bg-sunken); }
+.docs-main table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0 24px;
+  font-size: 13.5px;
+  display: table;
+}
+
+.docs-main th,
+.docs-main td {
+  padding: 10px 14px;
+  text-align: left;
+  border: 1px solid var(--border);
+  vertical-align: top;
+  color: var(--fg-muted);
+}
+
+.docs-main thead th {
+  font-family: var(--font-family-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--fg-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: var(--bg-sunken);
+  border-color: var(--border);
+}
+
+.docs-main tbody tr:hover td {
+  background: var(--bg-sunken);
+}
 
 /* ─── Callout ─── */
-.callout { margin: 24px 0; padding: 16px 20px; background: var(--bg-sunken); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 6px; }
-.callout strong { color: var(--accent-fg); display: block; margin-bottom: 6px; }
-.callout p { margin: 0; color: var(--fg-muted); font-size: 14px; }
-.callout-ok { border-left-color: var(--success); }
-.callout-ok strong { color: var(--success); }
+.callout {
+  margin: 24px 0;
+  padding: 16px 20px;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+}
+
+.callout strong {
+  color: var(--accent-fg);
+  display: block;
+  margin-bottom: 6px;
+}
+
+.callout p {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 14px;
+}
+
+.callout-ok {
+  border-left-color: var(--success);
+}
+
+.callout-ok strong {
+  color: var(--success);
+}
 
 /* ─── Sig block ─── */
-.sig { padding: 14px 18px; background: var(--bg-sunken); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: 6px; margin: 0 0 24px; }
-.sig h4 { margin: 0 0 6px; font-family: var(--font-family-mono); font-size: 10.5px; color: var(--fg-subtle); text-transform: uppercase; letter-spacing: 0.08em; }
-.sig pre { margin: 0; padding: 0; background: none; border: 0; }
+.sig {
+  padding: 14px 18px;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  margin: 0 0 24px;
+}
+
+.sig h4 {
+  margin: 0 0 6px;
+  font-family: var(--font-family-mono);
+  font-size: 10.5px;
+  color: var(--fg-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sig pre {
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: 0;
+}
 
 /* ─── Docs-main markdown prose overrides ─── */
-.docs-main { max-width: 780px; }
-.docs-main .crumb { font-family: var(--font-family-mono); font-size: 11.5px; color: var(--fg-subtle); text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 12px; }
-.docs-main h1 { font-family: var(--font-family-serif); font-weight: 500; font-size: 42px; line-height: 1.1; letter-spacing: -0.02em; margin: 0 0 24px; color: var(--fg); }
-.docs-main h2 { font-family: var(--font-family-serif); font-weight: 500; font-size: 26px; letter-spacing: -0.01em; margin: 48px 0 16px; color: var(--fg); padding-top: 12px; border-top: 1px solid var(--border); }
-.docs-main h2:first-of-type { border-top: 0; padding-top: 0; }
-.docs-main h3 { font-size: 18px; font-weight: 600; margin: 28px 0 10px; color: var(--fg); }
-.docs-main h4 { font-size: 14px; font-weight: 600; margin: 20px 0 8px; color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-.docs-main p { margin: 0 0 16px; color: var(--fg-muted); line-height: 1.7; }
-.docs-main p.lede { font-size: 19px; color: var(--fg); line-height: 1.5; margin-bottom: 32px; font-weight: 400; }
-.docs-main strong { color: var(--fg); font-weight: 600; }
-.docs-main ul, .docs-main ol { margin: 0 0 16px; padding-left: 22px; color: var(--fg-muted); line-height: 1.7; }
-.docs-main li { margin-bottom: 6px; }
-.docs-main code { font-family: var(--font-family-mono); font-size: 0.88em; background: var(--bg-sunken); color: var(--accent-fg); padding: 2px 6px; border-radius: 4px; border: 1px solid var(--border); }
-.docs-main pre { margin: 16px 0 24px; padding: 18px 20px; background: var(--bg-code); border: 1px solid var(--border); border-radius: 10px; font-size: 13px; overflow-x: auto; line-height: 1.55; }
-.docs-main pre code { background: none; padding: 0; border: 0; color: var(--fg); font-size: inherit; }
-.docs-main a { color: var(--accent-fg); text-decoration: underline; text-decoration-color: color-mix(in oklab, var(--accent) 40%, transparent); text-underline-offset: 3px; }
-.docs-main a:hover { text-decoration-color: var(--accent); }
-.docs-main .small { font-size: 13px; color: var(--fg-subtle); }
+.docs-main {
+  max-width: 780px;
+}
+
+.docs-main .crumb {
+  font-family: var(--font-family-mono);
+  font-size: 11.5px;
+  color: var(--fg-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 12px;
+}
+
+.docs-main h1 {
+  font-family: var(--font-family-serif);
+  font-weight: 500;
+  font-size: 42px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0 0 24px;
+  color: var(--fg);
+}
+
+.docs-main h2 {
+  font-family: var(--font-family-serif);
+  font-weight: 500;
+  font-size: 26px;
+  letter-spacing: -0.01em;
+  margin: 48px 0 16px;
+  color: var(--fg);
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.docs-main h2:first-of-type {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.docs-main h3 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 28px 0 10px;
+  color: var(--fg);
+}
+
+.docs-main h4 {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 20px 0 8px;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.docs-main p {
+  margin: 0 0 16px;
+  color: var(--fg-muted);
+  line-height: 1.7;
+}
+
+.docs-main p.lede {
+  font-size: 19px;
+  color: var(--fg);
+  line-height: 1.5;
+  margin-bottom: 32px;
+  font-weight: 400;
+}
+
+.docs-main strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+.docs-main ul,
+.docs-main ol {
+  margin: 0 0 16px;
+  padding-left: 22px;
+  color: var(--fg-muted);
+  line-height: 1.7;
+}
+
+.docs-main li {
+  margin-bottom: 6px;
+}
+
+.docs-main code {
+  font-family: var(--font-family-mono);
+  font-size: 0.88em;
+  background: var(--bg-sunken);
+  color: var(--accent-fg);
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+
+.docs-main pre {
+  margin: 16px 0 24px;
+  padding: 18px 20px;
+  background: var(--bg-code);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-size: 13px;
+  overflow-x: auto;
+  line-height: 1.55;
+}
+
+.docs-main pre code {
+  background: none;
+  padding: 0;
+  border: 0;
+  color: var(--fg);
+  font-size: inherit;
+}
+
+.docs-main a {
+  color: var(--accent-fg);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklab, var(--accent) 40%, transparent);
+  text-underline-offset: 3px;
+}
+
+.docs-main a:hover {
+  text-decoration-color: var(--accent);
+}
+
+.docs-main .small {
+  font-size: 13px;
+  color: var(--fg-subtle);
+}
 
 /* ─── Heading anchor links (section permalinks) ─── */
 /* Inline link icon appended after heading text; revealed on hover.
@@ -309,14 +635,176 @@ code, kbd, pre { font-family: var(--font-family-mono); }
   text-decoration: none;
   vertical-align: middle;
 }
+
 .docs-main h2:hover .heading-anchor,
 .docs-main h3:hover .heading-anchor {
   opacity: 1;
 }
+
 .heading-anchor:hover,
 .heading-anchor.is-copied {
   color: var(--accent-fg);
   opacity: 1;
 }
 
-[hidden] { display: none !important; }
+/* ── Toast ─────────────────────────────────────────────────────────── */
+.lume-toast {
+  position: fixed;
+  top: 1.25rem;
+  right: 1.25rem;
+  z-index: 9999;
+  background: var(--bg-raised);
+  color: var(--fg);
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--accent-fg);
+  border-radius: 12px;
+  width: 320px;
+  max-width: calc(100vw - 2rem);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, .25), 0 2px 8px rgba(0, 0, 0, .12);
+  opacity: 0;
+  transform: translateX(calc(100% + 1.5rem));
+  transition: transform 0.35s cubic-bezier(.34, 1.56, .64, 1), opacity 0.3s;
+  pointer-events: none;
+}
+
+.lume-toast.is-visible {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.toast-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.875rem 1rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.toast-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+}
+
+.toast-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--border);
+  background: var(--bg-sunken);
+  border-radius: 6px;
+  color: var(--fg-subtle);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.toast-close:hover {
+  color: var(--fg);
+  border-color: var(--border-strong);
+  background: var(--bg-raised);
+}
+
+.toast-url {
+  padding: 0.5rem 1rem;
+  font-family: var(--font-family-mono, monospace);
+  font-size: 11px;
+  color: var(--accent-fg);
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--border);
+  word-break: break-all;
+  line-height: 1.4;
+}
+
+.toast-desc {
+  padding: 0.625rem 1rem 0.75rem;
+  font-size: 12px;
+  color: var(--fg-muted);
+  line-height: 1.55;
+}
+.toast-progress {
+  height: 3px;
+  background: var(--border);
+  border-radius: 0 0 11px 11px;
+  overflow: hidden;
+  position: relative;
+}
+.toast-progress::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--accent-fg);
+  transform-origin: left center;
+  transform: scaleX(1);
+  animation: none;
+}
+.lume-toast.is-visible .toast-progress::after {
+  animation: toast-countdown var(--toast-duration, 6s) linear forwards;
+}
+@keyframes toast-countdown {
+  from { transform: scaleX(1); }
+  to   { transform: scaleX(0); }
+}
+
+/* ── Router mode tooltip ─────────────────────────────────────────── */
+.router-mode-wrap {
+  position: relative;
+}
+
+.router-tooltip {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  z-index: 200;
+  min-width: 230px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .2);
+  padding: 0.75rem 1rem;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-6px);
+  transition: opacity 0.15s, transform 0.15s;
+}
+
+.router-tooltip::before {
+  content: '';
+  position: absolute;
+  top: -5px;
+  right: 14px;
+  width: 8px;
+  height: 8px;
+  background: var(--bg-raised);
+  border-top: 1px solid var(--border-strong);
+  border-left: 1px solid var(--border-strong);
+  transform: rotate(45deg);
+}
+
+.router-mode-wrap:hover .router-tooltip {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.router-tooltip-mode {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-fg);
+  margin-bottom: 0.35rem;
+}
+
+.router-tooltip-body {
+  font-size: 12px;
+  color: var(--fg-muted);
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+}
+
+[hidden] {
+  display: none !important;
+}

--- a/scripts/build-site-assets.js
+++ b/scripts/build-site-assets.js
@@ -30,6 +30,14 @@ console.log('Copying assets...');
 copyDir(path.join(rootDir, 'docs'), path.join(publicDir, 'docs'));
 copyDir(path.join(rootDir, 'examples'), path.join(publicDir, 'examples'));
 
+// Copy 404.html into publicDir so Vite includes it in the dist output.
+// GitHub Pages serves this file for any unmatched URL (history-mode SPA fallback).
+fs.copyFileSync(
+  path.resolve(rootDir, 'gh-pages/404.html'),
+  path.join(publicDir, '404.html')
+);
+console.log('Copied 404.html to public/');
+
 // Inject import maps into examples/index.html files
 function injectImportMap(dir) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {


### PR DESCRIPTION
This PR significantly improves the LumeJS documentation site by upgrading the routing architecture, optimizing navigation performance, and adding essential UX features like heading permalinks and live router mode switching.

#### 🚀 Key Features

*   **Advanced SPA Routing**:
    *   **History Mode by Default**: Switched from hash-based routing to History API as the default for all environments.
    *   **GH Pages Fallback**: Implemented a robust `404.html` redirect loop that correctly reconstructs deep-linked paths on GitHub Pages, including project subfolder support.
    *   **Live Mode Switching**: Added a reactive toggle in the header that allows users to swap between `hash` and `history` modes instantly without a page reload.
*   **Persistent Documentation Shell**:
    *   Refactored the layout to move the sidebar, mobile drawer, and TOC outside the router outlet.
    *   Navigation now only swaps the `<article>` content, resulting in near-instant transitions while preserving the sidebar's scroll position and state.
*   **Heading Anchors & Permalinks**:
    *   H2 and H3 headings in documentation now feature clickable anchors that appear on hover.
    *   Supports smooth-scrolling and automatic clipboard copying of the direct link.
*   **Reactive Feedback System**:
    *   Implemented a lightweight toast notification system (with progress bars) and custom tooltips, driven entirely by Lume.js state to provide feedback for router changes and link copying.

#### 🛠 Technical Implementation
*   **Router Enhancements**: Updated `lume-router.js` to handle `BASE_URL` prefixing and `pushState` logic for project-specific domains (e.g., `username.github.io/repo/`).
*   **Layout Refactor**: Introduced `mountDocsShell` to isolate one-time setup of navigation elements from the route-driven content updates.
*   **Styling**: Added sleek micro-animations for toast notifications, tooltips, and heading hover effects.

#### ✅ Verification
*   **Deep-linking**: Verified that refreshing a nested doc page (e.g., `/docs/intro#signals`) correctly restores the URL and scrolls to the target heading via the 404 fallback.
*   **State Persistence**: Confirmed the docs sidebar remains interactive and doesn't "blink" or reset during navigation.
*   **Cross-Mode Compatibility**: Validated that the router correctly switches between `/#/path` and `/path` logic on the fly without breaking active state.