### PR TITLE
docs: document edge cases and refactor type definitions

### DIFF
--- a/docs/guides/forms.md
+++ b/docs/guides/forms.md
@@ -38,6 +38,11 @@ Checkboxes bind to a boolean. Radio groups bind to a string value — whichever 
 <input type="radio" name="theme" value="dark" data-bind="theme">
 ```
 
+## Known Limitations
+
+### `select multiple`
+The `data-bind` attribute does not currently support `<select multiple>`. Multi-select requires an array-based state model, while `data-bind` is designed for scalar values. If you need multi-select, manage the state manually using `addEventListener` and `watch`.
+
 ## Validation
 
 Use `watch` to run validation logic whenever a specific field changes. Write the result back to an error key in the store.

--- a/docs/guides/reactivity.md
+++ b/docs/guides/reactivity.md
@@ -81,6 +81,21 @@ store.todos.push({ text: 'buy milk' }); // subscribers NOT notified
 - **Class instances** with private fields — the Proxy wraps the instance, but internal `this` references may read the private backing store directly and bypass the proxy.
 - **Functions stored on the store** — methods stay plain and are not proxied.
 
+## Anti-patterns
+
+### `$subscribe` inside an auto-tracking effect
+Calling `store.$subscribe(key, fn)` inside an `effect()` that already auto-tracks that same key will cause the logic to execute twice: once for the auto-tracking re-run and once for the manual subscription.
+
+```js
+// ❌ ANTI-PATTERN — double notification
+effect(() => {
+  void store.count; // auto-tracks
+  store.$subscribe('count', () => { ... }); // also tracks
+});
+```
+
+Instead, use `watch` for single-key reactions or let the `effect` handle all tracking automatically.
+
 ## Cleanup
 
 Both `effect` and `bindDom` return a dispose function. Call it when the associated component or UI section is removed from the page to prevent memory leaks.

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -192,6 +192,7 @@ export function state(obj, options = {}) {
             return () => {
               if (listeners[key]) {
                 listeners[key] = listeners[key].filter(subscriber => subscriber !== effectFn);
+                if (listeners[key].length === 0) delete listeners[key];
               }
             };
           })();
@@ -271,6 +272,7 @@ export function state(obj, options = {}) {
     return () => {
       if (listeners[key]) {
         listeners[key] = listeners[key].filter(subscriber => subscriber !== fn);
+        if (listeners[key].length === 0) delete listeners[key];
       }
     };
   };

--- a/src/handlers/index.d.ts
+++ b/src/handlers/index.d.ts
@@ -5,25 +5,8 @@
  * Import from "lume-js/handlers" for tree-shaking.
  */
 
-/**
- * Handler interface for reactive data-* attribute binding.
- * Pass to bindDom() options.handlers to add new reactive attributes.
- *
- * @example
- * ```typescript
- * const tooltip: Handler = {
- *   attr: 'data-tooltip',
- *   apply(el, val) { el.title = val ?? ''; }
- * };
- * bindDom(root, store, { handlers: [tooltip] });
- * ```
- */
-export interface Handler {
-  /** Data attribute name (e.g., 'data-show', 'data-class-active') */
-  readonly attr: string;
-  /** Apply the reactive value to the element */
-  apply(el: HTMLElement, val: any): void;
-}
+import type { Handler } from '../index.js';
+
 
 /**
  * data-show="key" → Shows element when truthy (el.hidden = !val)


### PR DESCRIPTION
- Added select-multiple limitation to forms guide
- Added  anti-pattern documentation to reactivity guide
- Refactored handlers/index.d.ts to import Handler interface
- Implemented listener key cleanup in state.js to prevent memory accumulation