### PR TITLE
docs: surface design decisions — nav entry, contextual callouts, and anchor scroll fix

### DIFF
--- a/docs/api/addons/computed.md
+++ b/docs/api/addons/computed.md
@@ -27,6 +27,8 @@ An object with:
 
 ## Description
 
+> **→ Why is `computed` an addon and not part of core?** [See the design decision.](../../design/design-decisions.md#why-no-computed-properties-in-core)
+
 `computed` uses the same auto-tracking as `effect`: all store reads inside `fn` become dependencies. When any dependency changes, `fn` re-runs on the next microtask flush. The result is cached — `fn` never runs more than once per dependency change, no matter how many places read `computed.value`.
 
 ```js

--- a/docs/api/addons/repeat.md
+++ b/docs/api/addons/repeat.md
@@ -38,6 +38,8 @@ Imported from `lume-js/addons`.
 
 Use `render` alone for simple read-only lists. Use `create + update` for lists with event listeners — `create` runs once when the element is created, `update` runs on every data change.
 
+> **→ Why `create` + `update` instead of a single `render`?** [See the design decision.](../../design/design-decisions.md#why-create--update-instead-of-just-render)
+
 ## Returns
 
 A cleanup function.
@@ -109,6 +111,8 @@ repeat('#todo-list', store, 'todos', {
 | Key removed (immutable replace) | Removes row |
 | Reorder — same keys (immutable replace) | Moves existing nodes, `update` fires (index changed) |
 | Same key, item ref changed | Only that row's `update` fires |
+
+> **→ Why check both reference AND index to skip `update`?** [See the design decision.](../../design/design-decisions.md#why-check-both-reference-and-index-for-update-skip)
 
 ## Using with `computed`
 

--- a/docs/api/core/bindDom.md
+++ b/docs/api/core/bindDom.md
@@ -19,7 +19,7 @@ function bindDom(
 
 - `root` — The root element to scan. All descendants are included.
 - `store` — A reactive store created by `state()`.
-- `options.immediate` — If `true`, binds immediately instead of waiting for `DOMContentLoaded`.
+- `options.immediate` — If `true`, binds immediately instead of waiting for `DOMContentLoaded`. Default: `false` — [see why.](../../design/design-decisions.md#why-auto-ready-binddom-by-default)
 - `options.handlers` — Additional handler objects. See [Handlers](../../guides/handlers.md).
 
 ## Returns
@@ -29,6 +29,8 @@ A cleanup function. Call it to remove all bindings and event listeners created b
 ## Built-in bindings
 
 ### `data-bind` — two-way for forms, one-way for everything else
+
+> **→ Why one attribute?** [Why `data-bind` only, not `data-model` or `data-text`](../../design/design-decisions.md#why-data-bind-only-not-data-model-or-data-text)
 
 | Element | Property | Event |
 |---------|----------|-------|

--- a/docs/api/core/effect.md
+++ b/docs/api/core/effect.md
@@ -27,6 +27,8 @@ A dispose function. Call it to stop the effect and free its subscriptions.
 
 You can also pass an explicit `deps` array of `[store, ...keys]` tuples to skip auto-tracking and subscribe to specific keys only.
 
+> **→ Why support explicit deps?** [See the design decision.](../../design/design-decisions.md#why-support-explicit-dependencies-in-effect)
+
 ```js
 import { state, effect } from 'lume-js';
 

--- a/docs/api/core/state.md
+++ b/docs/api/core/state.md
@@ -48,6 +48,8 @@ const store = state({
 store.settings.theme = 'light'; // notifies subscribers of 'theme'
 ```
 
+> **→ Why not auto-proxy nested objects?** Explicit wrapping keeps performance predictable and ownership clear — [see the design decision.](../../design/design-decisions.md#why-nested-state-must-be-explicitly-wrapped)
+
 ## What's not reactive
 
 | Type | Supported | Notes |

--- a/docs/guides/core-concepts.md
+++ b/docs/guides/core-concepts.md
@@ -29,6 +29,8 @@ const store = state({
 store.user.name = 'Grace'; // works — user is its own reactive store
 ```
 
+> **→ Why not auto-proxy nested objects?** Explicit wrapping keeps performance predictable and ownership clear — [see the design decision.](../design/design-decisions.md#why-nested-state-must-be-explicitly-wrapped)
+
 ## 2. Bindings
 
 `bindDom()` connects your store to the DOM. It scans for `data-*` attributes and keeps them live — when the store changes, the page updates automatically.
@@ -42,6 +44,8 @@ The built-in `data-bind` attribute is **two-way** on form controls and **one-way
 ```
 
 For visibility, classes, attributes, and more, use **handlers** — or write your own. A handler is just a plain object with `attr` and `apply`. See [Handlers](handlers.md).
+
+> **→ Why one `data-bind` attribute?** [Why `data-bind` only, not `data-model` or `data-text`](../design/design-decisions.md#why-data-bind-only-not-data-model-or-data-text)
 
 ## 3. Effects
 
@@ -94,6 +98,8 @@ Your store sits in the middle. Bindings and effects subscribe to it. When you ch
 ```
 
 No virtual DOM, no component tree, no build step required.
+
+> **→ Why no virtual DOM?** Direct DOM writes are faster for small-to-medium UIs and keep the library tiny — [see the design decision.](../design/design-decisions.md#why-no-virtual-dom)
 
 ---
 

--- a/docs/guides/handlers.md
+++ b/docs/guides/handlers.md
@@ -20,6 +20,8 @@ When `bindDom` scans the DOM and finds an element with `data-tooltip="someKey"`:
 1. It subscribes to `store.someKey`.
 2. It calls `apply(el, store.someKey)` immediately, then again on every subsequent change.
 
+> **→ Why `data-*` attributes?** [See the design decision.](../design/design-decisions.md#why-data-attr-for-reactive-html-attributes)
+
 ## Built-in handlers
 
 The handlers below are exported from `lume-js/handlers`. They are opt-in — import only the ones you need.

--- a/docs/guides/lists.md
+++ b/docs/guides/lists.md
@@ -43,6 +43,8 @@ Use `render` alone for simple, read-only lists. Use `create` + `update` for list
 
 `repeat` subscribes to the array key on the store. To trigger a re-render, **replace the array** with a new reference — in-place mutations like `push` or `splice` are invisible to Lume because the array reference does not change:
 
+> **→ Why immutable updates?** Reference-equality checks are instant and require no Array monkey-patching — [see the design decision.](../design/design-decisions.md#why-no-loop-rendering-in-core-v-for-x-for)
+
 ```js
 // ❌ Mutations — NOT reactive, repeat() will not re-render
 store.todos.push(newTodo);

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -2,6 +2,8 @@
 
 Lume's update model is O(subscribers) — only the effects that read a changed key re-run, nothing else. The patterns below keep that guarantee working well as your app grows.
 
+> **→ Why no virtual DOM?** Direct DOM writes are faster for small-to-medium UIs and keep the library tiny — [see the design decision.](../design/design-decisions.md#why-no-virtual-dom)
+
 ## Use `repeat` for lists
 
 `innerHTML` rebuilds the entire list on every change — event listeners, focus state, and scroll position are all destroyed. `repeat` keys elements by ID and only touches what changed.

--- a/docs/guides/reactivity.md
+++ b/docs/guides/reactivity.md
@@ -6,6 +6,8 @@ Lume's reactivity is a thin layer over JavaScript's built-in `Proxy`. This page 
 
 `state(obj)` returns `new Proxy(obj, handlers)`. The handlers intercept two traps:
 
+> **→ Why only objects?** `state()` only accepts plain objects, never primitives — [see the design decision.](../design/design-decisions.md#why-only-objects-in-state-not-primitives)
+
 ```js
 // Simplified pseudocode of what state() does
 function state(target) {
@@ -49,6 +51,8 @@ After the function finishes, the context is cleared. Writing to a store key insi
 
 On write, Lume queues the notification with `queueMicrotask`. On the next microtask, it calls every subscriber registered for that key. DOM updates therefore happen after the current synchronous JavaScript task finishes.
 
+> **→ Why microtasks?** Batching writes lets multiple property changes collapse into one DOM update — [see the design decision.](../design/design-decisions.md#why-microtask-batching-instead-of-synchronous-updates)
+
 ## Nested objects
 
 Nested objects are **not** automatically reactive. The `get` trap returns `target[key]` directly without wrapping it in a new proxy. To make a nested object reactive, wrap it in its own `state()` call:
@@ -74,6 +78,8 @@ store.todos = [...store.todos, { text: 'buy milk' }];
 // ❌ NOT reactive — mutates the raw array directly
 store.todos.push({ text: 'buy milk' }); // subscribers NOT notified
 ```
+
+> **→ Why no auto-nested reactivity?** Explicit wrapping keeps performance predictable and ownership clear — [see the design decision.](../design/design-decisions.md#why-nested-state-must-be-explicitly-wrapped)
 
 ## What is not reactive
 

--- a/docs/guides/two-way-binding.md
+++ b/docs/guides/two-way-binding.md
@@ -2,6 +2,8 @@
 
 A single `data-bind` attribute handles all form controls. Lume inspects the element type and wires the correct DOM property and event automatically — you don't need to configure anything.
 
+> **→ Why one attribute?** [Why `data-bind` only, not `data-model` or `data-text`](../design/design-decisions.md#why-data-bind-only-not-data-model-or-data-text)
+
 ## The rules
 
 | Element | Property | Event |

--- a/gh-pages/src/lume-router.js
+++ b/gh-pages/src/lume-router.js
@@ -213,7 +213,16 @@ export function link(router) {
         if (url.pathname === curHash) return;
       }
 
-      router.go(url.pathname + url.search);
+      // Preserve the hash fragment: history mode appends it to the URL;
+      // hash mode embeds it as a path segment (# is already used for routing).
+      const headingId = url.hash.slice(1);
+      if (router.mode === 'history') {
+        router.go(url.pathname + url.search + (url.hash || ''));
+      } else if (headingId) {
+        router.go(url.pathname + url.search + '/' + headingId);
+      } else {
+        router.go(url.pathname + url.search);
+      }
     });
     link._installed = true;
   }

--- a/gh-pages/src/pages/docs.js
+++ b/gh-pages/src/pages/docs.js
@@ -22,6 +22,7 @@ export const DOCS_SITEMAP = [
   { slug: 'migration',            title: 'Migrating from 1.x',  category: 'Reference',       file: 'docs/guides/migration.md' },
   { slug: 'changelog',            title: 'Changelog',            category: 'Reference',       file: 'docs/CHANGELOG.md' },
   { slug: 'faq',                  title: 'FAQ',                  category: 'Reference',       file: 'docs/guides/faq.md' },
+  { slug: 'design-decisions',     title: 'Design decisions',     category: 'Design',          file: 'docs/design/design-decisions.md' },
 ];
 
 // Reverse map: file path → slug (for link rewriting)

--- a/gh-pages/src/pages/docs.js
+++ b/gh-pages/src/pages/docs.js
@@ -20,7 +20,6 @@ export const DOCS_SITEMAP = [
   { slug: 'tutorial-todo',        title: 'Build a Todo app',     category: 'Tutorials',       file: 'docs/tutorials/build-todo-app.md' },
   { slug: 'tutorial-tic-tac-toe', title: 'Build Tic-Tac-Toe',   category: 'Tutorials',       file: 'docs/tutorials/build-tic-tac-toe.md' },
   { slug: 'migration',            title: 'Migrating from 1.x',  category: 'Reference',       file: 'docs/guides/migration.md' },
-  { slug: 'changelog',            title: 'Changelog',            category: 'Reference',       file: 'docs/CHANGELOG.md' },
   { slug: 'faq',                  title: 'FAQ',                  category: 'Reference',       file: 'docs/guides/faq.md' },
   { slug: 'design-decisions',     title: 'Design decisions',     category: 'Design',          file: 'docs/design/design-decisions.md' },
 ];
@@ -58,10 +57,14 @@ export async function fetchDoc(slug) {
   const md = await res.text();
   let content = md.replace(/^---[\s\S]+?---\n?/, '').trim();
 
-  // Strip trailing markdown page-nav (--- section with ← Previous / Next → links)
-  content = content.replace(/\n---\n[\s\S]*$/, (match) =>
-    /Previous|Next|←|→/.test(match) ? '' : match
-  );
+  // Strip trailing markdown page-nav (--- section with ← Previous / Next → links).
+  // Check only the LAST --- block — not the first. Docs that use → inside bullet
+  // points (e.g. design-decisions.md) would have their body stripped by a greedy match.
+  const lastHr = content.lastIndexOf('\n---\n');
+  if (lastHr !== -1) {
+    const tail = content.slice(lastHr);
+    if (/Previous|Next|←|→/.test(tail)) content = content.slice(0, lastHr);
+  }
 
   if (typeof marked === 'undefined') return `<pre>${content}</pre>`;
 


### PR DESCRIPTION
# Surface design decisions throughout the docs

The Design Decisions page existed in the repo but was invisible — not linked from the sidebar, not referenced from any guide, and broken when you did find it. This PR fixes all three problems.

## What changed

**Design Decisions is now a first-class doc page.** It appears in the sidebar under a new "Design" category and is reachable from `/docs/design-decisions`.

**Readers can jump to the rationale while reading.** Sixteen `→ Why?` blockquote callouts were added across 11 guide and API pages — wherever a design choice might raise a question (`Why immutable updates? Why no virtual DOM? Why one `data-bind` attribute?`). Each one links directly to the relevant section on the Design Decisions page, so the context is one click away instead of buried in a separate document.

**Two bugs were fixed that had been silently breaking the page.**

The first was in `fetchDoc`: it used a greedy regex to strip the trailing `← Previous / Next →` nav footer from fetched markdown. Design Decisions has a `---` separator after its intro paragraph (to visually divide the philosophy section from the API decisions), and its body uses `→` arrows in bullet points throughout. The regex matched from that first `---` all the way to the end of the file, stripping the entire body. The fix checks only the *last* `---` block using `lastIndexOf`.

The second was in the router's `link()` handler: it called `router.go(pathname + search)`, silently dropping the hash fragment. So clicking any cross-doc anchor like `/docs/design-decisions#why-no-virtual-dom` navigated to the right page but cleared `location.hash`, leaving the scroll target empty and the page stuck at the top. The fix appends the hash in history mode and embeds it as a path segment in hash mode (since `#` is reserved for routing).