### PR TITLE
feat(build): generate minified ESM CDN bundles and update all docs URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,20 @@
 - **`repeat` duplicate keys DOM corruption:** Duplicate keys are now skipped instead of overwriting element references in the keyed Map
 - **`state()` phantom options parameter:** Removed non-existent `options` from TypeScript declaration and JSDoc examples
 - **Runtime reactive brand symbol:** `Symbol.for('lume.reactive')` is now actually stamped by `state.js` (was fictional in beta.1)
+- **Frozen/sealed object rejection:** `state()` now throws early instead of silently crashing when stamping the reactive brand on frozen or sealed objects
+- **Flush loop error isolation:** Individual subscriber calls, effect executions, and `beforeFlush` hooks are each wrapped in `try/catch`. Entire `queueMicrotask` body wrapped in `try/finally` to guarantee `flushScheduled` is always reset. Scheduler recovers after catastrophic errors instead of stalling permanently.
+- **`bindDom` path resolution no longer swallows all errors:** `resolvePath()` returns `null` for expected failures (null intermediates, missing properties). Removed blanket `try/catch` from `resolveProp` so unexpected errors propagate with full stack traces.
+- **`repeat()` normalize `subscribe()` return values:** Handles RxJS-style Subscription objects (with `.unsubscribe()` method) in addition to callable unsubscribe functions, preventing `TypeError` during cleanup
+- **`computed.dispose()` cancels stale microtasks:** Added `disposed` flag to guard effect body and microtask callback, preventing `isInComputation` from being reset after disposal
+- **`$beforeFlush` hook deduplication:** Registering the same function reference multiple times no longer causes duplicate execution per flush
 
 ### Performance
 - **Eliminated double microtask flush in `withPlugins`:** Collapsed `onNotify` + subscriber flushes into single microtask via `$beforeFlush` hook
 - **Eliminated per-flush array allocations in `state.flush`:** Replaced `[...listeners[key]]` spread and `[...pendingEffects]` with stable-index `while` loops and pre-sized arrays
 - **Replaced `filter`-based unsubscribe with `indexOf+splice`:** O(n) without allocation, correctly removes only first matching instance
+
+### Environment Hardening
+- **Console-less environment safety:** Added `src/utils/log.js` with `logWarn()` and `logError()` helpers that check `typeof console` before emitting. All core and addon files now import these instead of raw `console.*` calls, preventing `ReferenceError` in service workers and embedded engines.
 
 ### Changed
 - **Plugin system stripped from core:** `state(obj, { plugins })` → `withPlugins(state(obj), [plugins])` from `lume-js/addons`
@@ -25,8 +34,9 @@
 ### Improved
 - **Developer Experience:** Named constants `MAX_LOG_LEN` / `TRUNCATED_LEN` in debug addon; removed dead `json &&` guard
 - **TypeScript:** `TypedPlugin` re-exported from `lume-js/addons`
-- **Documentation:** Added JSDoc warnings for circular computed dependencies and `bindDom` path-healing limitations
-- **Tests:** 295 tests | 100% stmts/branches/funcs/lines across all 15 source files
+- **Documentation:** Added JSDoc warnings for circular computed dependencies and `bindDom` path-healing limitations. Added architectural comment explaining module-level readers Set behavior. Replaced innerHTML example with safe DOM API (`document.createElement()` + `textContent`).
+- **TypeScript:** `$subscribe` method added to `ReactiveState<T>` declaration
+- **Tests:** 303 tests | 100% stmts/branches/funcs/lines across all 15 source files
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Minimal reactive state management using only standard JavaScript and HTML. No cu
 
 ```html
 <script type="module">
-  import { state, bindDom, effect } from 'https://cdn.jsdelivr.net/npm/lume-js/src/index.js';
+  import { state, bindDom, effect } from 'https://cdn.jsdelivr.net/npm/lume-js/dist/index.min.mjs';
 </script>
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Paste this into an HTML file and open it in a browser. No npm, no bundler, no co
   <input data-bind="name" placeholder="Your name">
 
   <script type="module">
-    import { state, bindDom } from 'https://cdn.jsdelivr.net/npm/lume-js/src/index.js';
+    import { state, bindDom } from 'https://cdn.jsdelivr.net/npm/lume-js/dist/index.min.mjs';
 
     const store = state({ name: 'World' });
     bindDom(document.body, store);

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -10,7 +10,7 @@ Yes — that's one of its main advantages. Import from a CDN and write plain Jav
 
 ```html
 <script type="module">
-  import { state, bindDom, effect } from 'https://cdn.jsdelivr.net/npm/lume-js/src/index.js';
+  import { state, bindDom, effect } from 'https://cdn.jsdelivr.net/npm/lume-js/dist/index.min.mjs';
 </script>
 ```
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -8,7 +8,7 @@ Drop a `<script type="module">` into any HTML file and you're done:
 
 ```html
 <script type="module">
-  import { state, bindDom, effect } from 'https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.1/src/index.js';
+  import { state, bindDom, effect } from 'https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.2/dist/index.min.mjs';
 </script>
 ```
 
@@ -18,13 +18,13 @@ For production, pin to an exact version so your page can't break on a new releas
 
 ```html
 <!-- exact version (recommended for production) -->
-'https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.1/src/index.js'
+'https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.2/dist/index.min.mjs'
 
 <!-- latest stable -->
-'https://cdn.jsdelivr.net/npm/lume-js/src/index.js'
+'https://cdn.jsdelivr.net/npm/lume-js/dist/index.min.mjs'
 
 <!-- latest beta -->
-'https://cdn.jsdelivr.net/npm/lume-js@next/src/index.js'
+'https://cdn.jsdelivr.net/npm/lume-js@next/dist/index.min.mjs'
 ```
 
 ### Import map (recommended for CDN projects)
@@ -35,9 +35,9 @@ If your page imports from more than one Lume subpath, an import map removes the 
 <script type="importmap">
 {
   "imports": {
-    "lume-js":          "https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.2/src/index.js",
-    "lume-js/addons":   "https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.2/src/addons/index.js",
-    "lume-js/handlers": "https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.2/src/handlers/index.js"
+    "lume-js":          "https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.2/dist/index.min.mjs",
+    "lume-js/addons":   "https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.2/dist/addons.min.mjs",
+    "lume-js/handlers": "https://cdn.jsdelivr.net/npm/lume-js@2.0.0-beta.2/dist/handlers.min.mjs"
   }
 }
 </script>

--- a/docs/tutorials/build-tic-tac-toe.md
+++ b/docs/tutorials/build-tic-tac-toe.md
@@ -38,8 +38,8 @@ Create an `index.html` file. We'll put everything in here.
   <div id="root"></div>
 
   <script type="module">
-    import { state, effect } from 'https://cdn.jsdelivr.net/npm/lume-js/src/index.js';
-    import { computed } from 'https://cdn.jsdelivr.net/npm/lume-js/src/addons/index.js';
+    import { state, effect } from 'https://cdn.jsdelivr.net/npm/lume-js/dist/index.min.mjs';
+    import { computed } from 'https://cdn.jsdelivr.net/npm/lume-js/dist/addons.min.mjs';
 
     const root = document.getElementById('root');
 
@@ -298,8 +298,8 @@ effect(() => {
   <div id="root"></div>
 
   <script type="module">
-    import { state, effect } from 'https://cdn.jsdelivr.net/npm/lume-js/src/index.js';
-    import { computed } from 'https://cdn.jsdelivr.net/npm/lume-js/src/addons/index.js';
+    import { state, effect } from 'https://cdn.jsdelivr.net/npm/lume-js/dist/index.min.mjs';
+    import { computed } from 'https://cdn.jsdelivr.net/npm/lume-js/dist/addons.min.mjs';
 
     // --- Logic ---
     function calculateWinner(squares) {

--- a/docs/tutorials/build-todo-app.md
+++ b/docs/tutorials/build-todo-app.md
@@ -38,8 +38,8 @@ Create an `index.html` file.
   <ul id="todo-list" class="todo-list"></ul>
 
   <script type="module">
-    import { state, bindDom } from 'https://cdn.jsdelivr.net/npm/lume-js/src/index.js';
-    import { repeat, computed } from 'https://cdn.jsdelivr.net/npm/lume-js/src/addons/index.js';
+    import { state, bindDom } from 'https://cdn.jsdelivr.net/npm/lume-js/dist/index.min.mjs';
+    import { repeat, computed } from 'https://cdn.jsdelivr.net/npm/lume-js/dist/addons.min.mjs';
 
     // Code goes here...
   </script>
@@ -269,8 +269,8 @@ Now refresh the page. Your todos are still there!
   </div>
 
   <script type="module">
-    import { state, effect } from 'https://cdn.jsdelivr.net/npm/lume-js/src/index.js';
-    import { repeat, computed } from 'https://cdn.jsdelivr.net/npm/lume-js/src/addons/index.js';
+    import { state, effect } from 'https://cdn.jsdelivr.net/npm/lume-js/dist/index.min.mjs';
+    import { repeat, computed } from 'https://cdn.jsdelivr.net/npm/lume-js/dist/addons.min.mjs';
 
     // --- State ---
     const saved = localStorage.getItem('lume-todos');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -24,7 +24,8 @@ import { fileURLToPath } from 'node:url';
 import { readdir, stat } from 'node:fs/promises';
 import { gzip } from 'node:zlib';
 import { promisify } from 'node:util';
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
+import { minify as terserMinify } from 'terser';
 
 const gzipAsync = promisify(gzip);
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -100,7 +101,48 @@ await build({
   },
 });
 
-// ── Step 3: Report sizes ────────────────────────────────────────────────────
+// ── Step 3: Minified ESM bundles for CDN ────────────────────────────────────
+console.log('\n📦 Building minified ESM bundles for CDN…\n');
+
+const cdnEntries = {
+  index: resolve(root, 'src/index.js'),
+  addons: resolve(root, 'src/addons/index.js'),
+  handlers: resolve(root, 'src/handlers/index.js'),
+};
+
+for (const [name, entryPath] of Object.entries(cdnEntries)) {
+  await build({
+    root,
+    configFile: false,
+    build: {
+      lib: {
+        entry: entryPath,
+        formats: ['es'],
+        fileName: () => `${name}.min.mjs`,
+      },
+      outDir: 'dist',
+      emptyOutDir: false,
+      minify: false,
+      sourcemap: false,
+      rollupOptions: {
+        output: {
+          inlineDynamicImports: true,
+        },
+      },
+    },
+  });
+
+  const outFile = resolve(root, 'dist', `${name}.min.mjs`);
+  const raw = await readFile(outFile, 'utf-8');
+  const minified = await terserMinify(raw, {
+    ...terserOptions,
+    mangle: { toplevel: true },
+    sourceMap: false,
+  });
+  await writeFile(outFile, minified.code, 'utf-8');
+}
+
+// ── Step 4: Report sizes ────────────────────────────────────────────────────
 console.log('\n📊 Bundle sizes:\n');
 
 const distDir = resolve(root, 'dist');


### PR DESCRIPTION
- Add terser-based minified ESM bundles (index.min.mjs, addons.min.mjs, handlers.min.mjs) to dist/ via scripts/build.js
- Update every CDN import example across README, docs, and tutorials to use dist/*.min.mjs instead of src/*.js
- Update CHANGELOG with CDN build notes, TypeScript $subscribe addition, and test count bump