### PR TITLE
chore(release): v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2.0.0] - 2026-05-05
+
+### Overview
+
+**Stable release of Lume.js v2.** The reactive core API is now frozen forever.
+
+This release incorporates all beta hardening work: scope-based read tracking via `withReadObserver`, the extracted plugin system via `withPlugins()`, comprehensive TypeScript declarations, minified CDN bundles, and 319 tests at 100% coverage. No breaking changes from v2.0.0-beta.3.
+
+### Highlights
+- **Core API frozen:** `state()`, `effect()`, `bindDom()` — signatures are permanent
+- **319 tests** | 100% stmts/branches/funcs/lines across all 16 source files
+- **Core bundle:** 2.45KB gzipped / 3KB budget (81.5%)
+- **Zero breaking changes** from v2.0.0-beta.3
+
+---
+
 ## [2.0.0-beta.3] - 2026-05-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 Minimal reactive state management using only standard JavaScript and HTML. No custom syntax, no build step required, no framework lock-in.
 
-> **Current Release:** v2.0.0-beta.3 | **Stability Contract:** Core API is frozen forever  
-> Install: `npm install lume-js@next`  
+> **Current Release:** v2.0.0 | **Stability Contract:** Core API is frozen forever  
+> Install: `npm install lume-js`  
 > Bundle size: ~2.45KB gzipped | 319 tests passing
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.0--beta.3-orange.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-2.0.0-orange.svg)](package.json)
 [![Tests](https://img.shields.io/badge/tests-319%20passing-brightgreen.svg)](tests/)
 [![Size](https://img.shields.io/badge/core-2.45KB-blue.svg)](scripts/check-size.js)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lume-js",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0",
   "description": "Minimal reactive state management using only standard JavaScript and HTML - no custom syntax, no build step required",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary

This PR promotes v2.0.0-beta.3 to stable. No code changes — only version bump, README sync, and CHANGELOG update.

**319 tests passing | 100% coverage | 2.45KB gzipped core.**

---

## What's in this release

- **Version bump**: `2.0.0-beta.3` → `2.0.0`
- **README updated**: Stable install command (`npm install lume-js`), stable version badge
- **CHANGELOG updated**: `[2.0.0]` stable section added with frozen API contract

---

## Checklist

- [x] All tests pass (319/319)
- [x] 100% coverage maintained across 16 source files
- [x] `npm run typecheck` — zero errors
- [x] `npm run size` — under 3KB budget
- [x] No breaking changes from beta.3