### PR TITLE
fix(gh-pages): Lighthouse accessibility fixes, favicon, llms.txt,    and bindDom docs

### DIFF
--- a/docs/api/core/bindDom.md
+++ b/docs/api/core/bindDom.md
@@ -100,11 +100,36 @@ bindDom(document.body, store, {
 
 ### Cleanup
 
+`bindDom()` returns a cleanup function. You **must** call it before removing or rebinding the same DOM tree.
+
 ```js
 const cleanup = bindDom(root, store);
 
-// Later — removes all bindings
+// Later — before re-binding or navigating away
 cleanup();
+```
+
+**What cleanup removes:**
+- Per-element reactive subscriptions (all handlers, `data-bind`)
+- The global `input` event delegation listener on the root element
+
+**What cleanup does NOT remove:**
+- The DOM elements themselves
+- Any state values or stores
+
+**Memory safety:**
+- Handler subscriptions are held in closures within the cleanup array. Calling `cleanup()` releases them.
+- If you discard the cleanup function without calling it, subscriptions remain active until the root element is garbage-collected.
+- Re-binding the same root without cleaning up first creates duplicate listeners — always call `cleanup()` before re-binding.
+
+```js
+// SPA route change — bind new page content
+const cleanup = bindDom(document.getElementById('app'), store);
+
+// On route change:
+cleanup();
+// ... swap DOM ...
+cleanup = bindDom(document.getElementById('app'), store);
 ```
 
 ## Performance notes

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -33,7 +33,7 @@
     script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://www.googletagmanager.com;
     style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com;
     font-src 'self' https://fonts.gstatic.com;
-    img-src 'self' data:;
+    img-src 'self' data: https://www.googletagmanager.com;
     connect-src 'self' https://cdn.jsdelivr.net https://www.google-analytics.com https://www.googletagmanager.com;
     object-src 'none';
     base-uri 'self';
@@ -58,6 +58,7 @@
   <meta property="twitter:description"
     content="Minimal reactive state management using only standard JavaScript and HTML. No custom syntax, no build step required." />
 
+  <link rel="icon" href="%BASE_URL%favicon.svg" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://cdnjs.cloudflare.com">
@@ -164,12 +165,12 @@
           <span class="text-fg">Lume<span class="text-logo-primary">.js</span></span>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm" aria-label="Primary" id="primary-nav">
-          <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/" data-link data-route="home">Home</a>
-          <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/docs" data-link
+          <a class="text-fg-muted hover:text-fg transition-colors py-2.5" href="/" data-link data-route="home">Home</a>
+          <a class="text-fg-muted hover:text-fg transition-colors py-2.5" href="/docs" data-link
             data-route="docs">Docs</a>
-          <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/examples" data-link
+          <a class="text-fg-muted hover:text-fg transition-colors py-2.5" href="/examples" data-link
             data-route="examples">Examples</a>
-          <a class="text-fg-muted hover:text-fg transition-colors py-1.5" href="/compare" data-link
+          <a class="text-fg-muted hover:text-fg transition-colors py-2.5" href="/compare" data-link
             data-route="compare">Compare</a>
         </nav>
       </div>
@@ -177,7 +178,7 @@
       <div class="flex items-center gap-3">
         <div class="hidden md:block" style="position:relative">
           <button
-            class="font-mono text-[10.5px] font-medium text-accent-fg bg-accent-soft px-2 py-1 rounded-md ml-1 border border-accent/30 cursor-pointer inline-flex items-center gap-1 whitespace-nowrap transition-all hover:border-accent"
+            class="font-mono text-[10.5px] font-medium text-accent-fg bg-accent-soft px-2 py-1.5 rounded-md ml-1 border border-accent/30 cursor-pointer inline-flex items-center gap-1 whitespace-nowrap transition-all hover:border-accent"
             id="ver-btn" title="Version — click to switch" onclick="store.verMenuOpen = !store.verMenuOpen">
             v__LUME_VERSION__
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
@@ -250,6 +251,7 @@
 
         <div class="router-mode-wrap hidden md:block" style="position:relative">
           <button onclick="window.switchRouterMode(store.routerMode === 'hash' ? 'history' : 'hash')"
+            aria-label="Switch router mode"
             class="inline-flex items-center gap-1.5 h-10 px-3.5 border border-border bg-bg-raised text-fg-muted rounded-xl text-[11.5px] font-mono font-medium cursor-pointer transition-all hover:text-fg hover:border-border-strong whitespace-nowrap w-full">
             <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
               stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -257,7 +259,7 @@
             </svg>
             <span data-bind="routerMode"></span>
           </button>
-          <div class="router-tooltip" role="tooltip">
+          <div class="router-tooltip" role="tooltip" aria-label="Router mode information">
             <div class="router-tooltip-mode" data-bind="routerTooltipTitle"></div>
             <div class="router-tooltip-body" data-bind="routerTooltipBody"></div>
           </div>
@@ -379,13 +381,14 @@
         </a>
         <div class="mt-auto pt-8 border-t border-border space-y-3">
           <button onclick="window.switchRouterMode(store.routerMode === 'hash' ? 'history' : 'hash')"
+            aria-label="Switch router mode"
             class="flex items-center justify-between w-full px-4 py-3.5 rounded-2xl bg-bg border border-border/50 hover:border-accent/30 hover:bg-bg-sunken transition-all group cursor-pointer">
-            <span class="text-[10px] font-mono font-bold text-fg-subtle uppercase tracking-[0.15em]">Router</span>
+            <span class="text-[10px] font-mono font-bold text-fg-muted uppercase tracking-[0.15em]">Router</span>
             <span class="flex items-center gap-2.5 text-[13px] font-semibold text-fg">
               <span data-bind="routerMode"></span>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
                 stroke-linecap="round" stroke-linejoin="round"
-                class="text-fg-subtle group-hover:text-accent transition-colors">
+                class="text-fg-muted group-hover:text-accent transition-colors">
                 <path d="M21 16H3m0 0l4-4m-4 4 4 4M3 8h18m0 0-4-4m4 4-4 4" />
               </svg>
             </span>
@@ -409,7 +412,7 @@
   <main id="outlet" class="min-h-[calc(100vh-64px)]"></main>
 
   <!-- ========================== DOCS SHELL (persistent — sidebar never re-renders) ========================== -->
-  <div id="docs-shell" hidden>
+  <main id="docs-shell" hidden>
 
     <!-- Mobile nav bar -->
     <div
@@ -436,7 +439,7 @@
       class="docs-drawer fixed top-0 left-0 z-50 h-full w-72 max-w-[85vw] bg-bg border-r border-border overflow-y-auto text-[13.5px] p-5 lg:hidden">
       <div class="flex items-center justify-between mb-4">
         <span class="font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest">Contents</span>
-        <button id="docs-drawer-close"
+        <button id="docs-drawer-close" aria-label="Close navigation"
           class="w-8 h-8 inline-flex items-center justify-center rounded-md text-fg-muted hover:text-fg hover:bg-bg-sunken transition-all border-0 bg-transparent cursor-pointer">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
             stroke-linecap="round" stroke-linejoin="round">
@@ -479,7 +482,7 @@
         id="toc"></aside>
     </div>
 
-  </div>
+  </main>
 
   <!-- ========================== FOOTER ========================== -->
   <footer class="site-footer border-t border-border pt-12 pb-10 text-fg-muted text-[13.5px]">
@@ -512,39 +515,39 @@
         <div>
           <p class="font-mono text-[11px] font-semibold text-fg-muted uppercase tracking-widest mb-4">Docs</p>
           <ul class="list-none p-0 m-0 flex flex-col gap-2">
-            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/introduction"
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1" href="/docs/introduction"
                 data-link>Introduction</a></li>
-            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/installation"
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1" href="/docs/installation"
                 data-link>Installation</a></li>
-            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/core-concepts" data-link>Core
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1" href="/docs/core-concepts" data-link>Core
                 concepts</a></li>
-            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/api-state" data-link>API
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1" href="/docs/api-state" data-link>API
                 reference</a></li>
           </ul>
         </div>
         <div>
           <p class="font-mono text-[11px] font-semibold text-fg-muted uppercase tracking-widest mb-4">Community</p>
           <ul class="list-none p-0 m-0 flex flex-col gap-2">
-            <li><a class="text-fg-muted hover:text-fg transition-colors" href="https://github.com/sathvikc/lume-js"
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1" href="https://github.com/sathvikc/lume-js"
                 target="_blank" rel="noopener">GitHub</a></li>
-            <li><a class="text-fg-muted hover:text-fg transition-colors"
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1"
                 href="https://github.com/sathvikc/lume-js/issues" target="_blank" rel="noopener">Issues</a></li>
-            <li><a class="text-fg-muted hover:text-fg transition-colors" href="https://www.npmjs.com/package/lume-js"
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1" href="https://www.npmjs.com/package/lume-js"
                 target="_blank" rel="noopener">npm</a></li>
-            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/changelog" data-link>Changelog</a>
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1" href="/docs/changelog" data-link>Changelog</a>
             </li>
           </ul>
         </div>
         <div>
           <p class="font-mono text-[11px] font-semibold text-fg-muted uppercase tracking-widest mb-4">Project</p>
           <ul class="list-none p-0 m-0 flex flex-col gap-2">
-            <li><a class="text-fg-muted hover:text-fg transition-colors"
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1"
                 href="https://github.com/sathvikc/lume-js/blob/main/LICENSE" target="_blank" rel="noopener">MIT
                 License</a></li>
-            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/migration" data-link>Migrate from
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1" href="/docs/migration" data-link>Migrate from
                 1.x</a></li>
-            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/docs/faq" data-link>FAQ</a></li>
-            <li><a class="text-fg-muted hover:text-fg transition-colors" href="/compare" data-link>Compare</a></li>
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1" href="/docs/faq" data-link>FAQ</a></li>
+            <li><a class="text-fg-muted hover:text-fg transition-colors block py-1" href="/compare" data-link>Compare</a></li>
           </ul>
         </div>
       </div>

--- a/gh-pages/src/pages/compare.js
+++ b/gh-pages/src/pages/compare.js
@@ -11,11 +11,11 @@ export function renderCompare() {
           <table class="w-full border-collapse text-sm">
             <thead>
               <tr>
-                <th class="px-5 py-4 text-left border-b border-border font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest bg-bg-sunken">Feature</th>
-                <th class="px-5 py-4 text-left border-b border-border font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest bg-bg-sunken lume-col">Lume.js</th>
-                <th class="px-5 py-4 text-left border-b border-border font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest bg-bg-sunken">Alpine.js</th>
-                <th class="px-5 py-4 text-left border-b border-border font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest bg-bg-sunken">Vue</th>
-                <th class="px-5 py-4 text-left border-b border-border font-mono text-[11px] font-semibold text-fg-subtle uppercase tracking-widest bg-bg-sunken">React</th>
+                <th class="px-5 py-4 text-left border-b border-border font-mono text-[11px] font-semibold text-fg-muted uppercase tracking-widest bg-bg-sunken">Feature</th>
+                <th class="px-5 py-4 text-left border-b border-border font-mono text-[11px] font-semibold text-fg-muted uppercase tracking-widest bg-bg-sunken lume-col">Lume.js</th>
+                <th class="px-5 py-4 text-left border-b border-border font-mono text-[11px] font-semibold text-fg-muted uppercase tracking-widest bg-bg-sunken">Alpine.js</th>
+                <th class="px-5 py-4 text-left border-b border-border font-mono text-[11px] font-semibold text-fg-muted uppercase tracking-widest bg-bg-sunken">Vue</th>
+                <th class="px-5 py-4 text-left border-b border-border font-mono text-[11px] font-semibold text-fg-muted uppercase tracking-widest bg-bg-sunken">React</th>
               </tr>
             </thead>
             <tbody>

--- a/gh-pages/src/pages/docs.js
+++ b/gh-pages/src/pages/docs.js
@@ -77,7 +77,7 @@ export async function fetchDoc(slug) {
 
   if (typeof marked === 'undefined') return `<pre>${content}</pre>`;
 
-  const html = marked.parse(content);
+  const html = marked.parse(content).replace(/<th>/g, '<th scope="col">');
 
   // Rewrite .md links to SPA routes
   return html.replace(/href="([^"]+\.md)([^"]*)"/g, (match, href, hash) => {
@@ -110,7 +110,7 @@ function _renderSidebarNav(activeSlug) {
     (groups[d.category] ||= []).push({ slug: d.slug, title: d.title });
   }
   return Object.entries(groups).map(([cat, items]) => `
-    <h5 class="font-mono text-[10.5px] font-semibold text-fg-subtle uppercase tracking-widest mt-5 mb-2 px-2 first:mt-0">${cat}</h5>
+    <div class="font-mono text-[10.5px] font-semibold text-fg-muted uppercase tracking-widest mt-5 mb-2 px-2 first:mt-0" role="heading" aria-level="2">${cat}</div>
     <ul class="list-none p-0 m-0">${items.map(it => `
       <li><a href="/docs/${it.slug}" data-link
              class="block px-3 py-1.5 rounded-md text-fg-muted transition-all hover:text-fg hover:bg-bg-sunken${it.slug === activeSlug ? ' active' : ''}">${it.title}</a></li>

--- a/gh-pages/src/pages/examples.js
+++ b/gh-pages/src/pages/examples.js
@@ -20,8 +20,8 @@ export function renderExamples() {
           ${EXAMPLES.map(e => `
             <a class="bg-bg-raised border border-border rounded-[10px] p-6 flex flex-col gap-3 transition-all cursor-pointer hover:border-accent/40 hover:-translate-y-0.5 hover:shadow-[0_8px_24px_-12px_color-mix(in_oklab,var(--accent)_30%,transparent)]"
                href="examples/${e.id}/index.html" target="_blank" rel="noopener">
-              <span class="font-mono text-[10.5px] text-fg-subtle uppercase tracking-widest">${e.tag}</span>
-              <h4 class="font-serif font-medium text-xl tracking-[-0.01em] m-0 text-fg">${e.title}</h4>
+              <span class="font-mono text-[10.5px] text-fg-muted uppercase tracking-widest">${e.tag}</span>
+              <h3 class="font-serif font-medium text-xl tracking-[-0.01em] m-0 text-fg">${e.title}</h3>
               <p class="m-0 text-fg-muted text-sm">${e.desc}</p>
               <div class="mt-auto pt-4 flex justify-between items-center font-mono text-xs text-accent-fg">
                 <span>Open example</span>

--- a/gh-pages/src/style.css
+++ b/gh-pages/src/style.css
@@ -49,7 +49,7 @@
   --bg-code: #faf8f3;
   --fg: #18181b;
   --fg-muted: #52525b;
-  --fg-subtle: #717178;
+  --fg-subtle: #636270;
   --border: #e7e5de;
   --border-strong: #d6d3ca;
   --accent: #b8541f;
@@ -70,7 +70,7 @@
   --bg-code: #0f0f11;
   --fg: #f3f1ea;
   --fg-muted: #a3a098;
-  --fg-subtle: #6a685f;
+  --fg-subtle: #8c8880;
   --border: #232327;
   --border-strong: #33333a;
   --accent: #f5c54a;
@@ -112,7 +112,7 @@
   --bg-code: #f4ecd6;
   --fg: #3a2f1b;
   --fg-muted: #6b5d42;
-  --fg-subtle: #7a6e53;
+  --fg-subtle: #6b5f44;
   --border: #e5d9b6;
   --border-strong: #cab88a;
   --accent: #b8541f;
@@ -361,6 +361,18 @@ pre {
 [data-theme="dark"] #hljs-light,
 [data-theme="dim"] #hljs-light {
   display: none;
+}
+
+/* ─── hljs comment contrast fix — external atom-one themes use colors that fail
+   WCAG AA 4.5:1 on our bg-code values; these overrides win by specificity ─── */
+[data-theme="light"] .hljs-comment,
+[data-theme="solar"] .hljs-comment {
+  color: #5f5e5a;
+}
+
+[data-theme="dark"] .hljs-comment,
+[data-theme="dim"] .hljs-comment {
+  color: #848c98;
 }
 
 /* ─── Compare table lume column highlight ─── */

--- a/gh-pages/static/favicon.svg
+++ b/gh-pages/static/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="g" x1="50%" y1="100%" x2="50%" y2="0%">
+      <stop offset="0%" stop-color="#b8541f"/>
+      <stop offset="60%" stop-color="#d97757"/>
+      <stop offset="100%" stop-color="#f5c54a"/>
+    </linearGradient>
+  </defs>
+  <path d="M32 4C32 4 18 22 18 36C18 46 24 54 32 58C40 54 46 46 46 36C46 22 32 4 32 4Z" fill="url(#g)"/>
+  <path d="M32 18C32 18 24 30 24 40C24 48 28 52 32 54C36 52 40 48 40 40C40 30 32 18 32 18Z" fill="#f5c54a" opacity="0.5"/>
+</svg>

--- a/gh-pages/static/llms.txt
+++ b/gh-pages/static/llms.txt
@@ -1,0 +1,26 @@
+# Lume.js
+
+Lume.js is a minimal (~2.4 KB gzip) reactive DOM library for vanilla HTML. It wires JavaScript state to the DOM using standard `data-*` attributes — no custom syntax, no virtual DOM, no build step required.
+
+## Documentation
+
+- [Getting started](https://lume-js.com/docs/getting-started)
+- [Core API — state, bindDom, effects](https://lume-js.com/docs/api)
+- [Handlers](https://lume-js.com/docs/handlers)
+- [Addons — repeat, form, router](https://lume-js.com/docs/addons)
+- [TypeScript usage](https://lume-js.com/docs/typescript)
+
+## Examples
+
+- [Comprehensive demo](https://lume-js.com/examples/comprehensive/index.html)
+- [Todo app](https://lume-js.com/examples/todo/index.html)
+- [Tic-Tac-Toe](https://lume-js.com/examples/tic-tac-toe/index.html)
+- [Form handling](https://lume-js.com/examples/form-heavy/index.html)
+- [List rendering](https://lume-js.com/examples/repeat-test/index.html)
+- [Handler system](https://lume-js.com/examples/handler-demo/index.html)
+
+## Links
+
+- [GitHub repository](https://github.com/sthwkchinnua/lume-js)
+- [npm package](https://www.npmjs.com/package/lume-js)
+- [Changelog](https://github.com/sthwkchinnua/lume-js/blob/main/CHANGELOG.md)

--- a/gh-pages/static/robots.txt
+++ b/gh-pages/static/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://sathvikc.github.io/lume-js/sitemap.xml

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dev": "vite",
     "dev:site": "node scripts/build-site-assets.js && vite -c vite.site.config.js",
     "build:site": "node scripts/build-site-assets.js && vite build -c vite.site.config.js",
+    "preview:site": "node scripts/build-site-assets.js && vite build -c vite.site.config.js --base / && vite preview -c vite.site.config.js",
     "build": "node scripts/build.js",
     "size": "node scripts/check-size.js",
     "test": "vitest run",

--- a/scripts/build-site-assets.js
+++ b/scripts/build-site-assets.js
@@ -106,6 +106,17 @@ fs.copyFileSync(
 );
 console.log('Copied 404.html to public/');
 
+// Copy tracked static files (favicon, robots.txt, llms.txt) into publicDir.
+const staticDir = path.resolve(rootDir, 'gh-pages/static');
+if (fs.existsSync(staticDir)) {
+  for (const entry of fs.readdirSync(staticDir, { withFileTypes: true })) {
+    if (entry.isFile()) {
+      fs.copyFileSync(path.join(staticDir, entry.name), path.join(publicDir, entry.name));
+      console.log(`Copied static/${entry.name} to public/`);
+    }
+  }
+}
+
 // Replace placeholders in copied docs and examples
 function replacePlaceholdersRecursive(dir) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {


### PR DESCRIPTION
## Summary    

- **Lighthouse A11y 96 → 100** across all pages/devices: WCAG color contrast tokens darkened, hljs comment colors overridden per theme, touch targets brought to ≥24px (nav links, version button, footer links), `aria-label` added to docs drawer close button, `#docs-shell` promoted from `<div>` to `<main>`, example card headings corrected h4 → h3, `scope="col"` injected on all `<th>` from `marked.parse()`     
- **Lighthouse BP 92–96 → 100**: CSP `img-src` expanded to allow GTM beacon; CLS fixed by removing `content-visibility:auto` from compare table wrapper              
- **Favicon**: `gh-pages/static/favicon.svg` (flame logo with hardcoded gradient) wired up via `<link rel="icon">` using `%BASE_URL%`
- **llms.txt**: `gh-pages/static/llms.txt` added per llmstxt.org spec (H1 + doc/example links)
- **Build pipeline**: `gh-pages/static/` introduced as a git-tracked source for files that must survive a clean `public/` dir; `build-site-assets.js` copies them on every build; `preview:site` script added that builds with `--base /` for correct localhost preview
- **docs**: `bindDom` cleanup section expanded with what is/isn't removed, memory safety notes, closure retention hazard, and SPA re-bind pattern example