### PR TITLE
chore(release): prepare v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [2.1.0] - 2026-05-09
+
+### Added
+
+- **`repeat()` — create-returned cleanup functions:** `create()` can now return a cleanup function that `repeat()` calls automatically when the element is removed (list update or full cleanup). Replaces the fragile `el._lumeCleanup` DOM-property pattern with an internal `Map<key, fn>` — no DOM pollution.
+
+  ```js
+  repeat('#list', store, 'items', {
+    create(item, el) {
+      const handler = () => doSomething(item);
+      el.addEventListener('click', handler);
+      return () => el.removeEventListener('click', handler); // auto-called on removal
+    },
+    update(item, el) { /* sync content */ },
+  });
+  ```
+
+  The optional `remove` callback remains for secondary teardown, called after the create-returned cleanup.
+
+- **`repeat()` — cleanup error isolation:** All cleanup function calls are wrapped in `try/catch` with `logError`, so a single buggy cleanup no longer aborts the remaining cleanup loop or leaves the internal `cleanupByKey` Map in an inconsistent state. Covers element-removal, reactive-store full cleanup, and non-reactive-store full cleanup paths.
+
+### Tests
+
+- **339 tests passing** (from 321) | 10 new tests added across `repeat.test.js`
+  - Auto-cleanup on element removal
+  - Full cleanup for reactive and non-reactive stores
+  - `remove` callback ordering (fires after create-returned cleanup)
+  - Error isolation: a throwing cleanup does not prevent subsequent cleanups
+  - `hydrateState` — document-undefined branch coverage
+
+### Documentation
+
+- **`bindDom` cleanup guidance expanded:** API reference now documents retention semantics, when to call the returned cleanup, and how to pair `bindDom` with `repeat()` for component-style teardown.
+
+### Site / gh-pages
+
+- **CI fix:** `lumeGlobalShimPlugin` moved to `enforce: pre` to fix gh-pages build failure in Vite plugin pipeline.
+- **Performance:** `highlight.js` bundled from npm instead of CDN; `lume.global.js` loaded as parallel global script to reduce render-blocking.
+- **Accessibility:** Contrast and static asset fixes on the documentation site.
+
+---
+
 ## [2.0.1] - 2026-05-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 Minimal reactive state management using only standard JavaScript and HTML. No custom syntax, no build step required, no framework lock-in.
 
-> **Current Release:** v2.0.1
+> **Current Release:** v2.1.0
 > Install: `npm install lume-js`  
-> Bundle size: ~2.44KB gzipped | 330 tests passing
+> Bundle size: ~2.44KB gzipped | 339 tests passing
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.0.1-orange.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-2.1.0-orange.svg)](package.json)
 [![Tests](https://img.shields.io/badge/tests-339%20passing-brightgreen.svg)](tests/)
 [![Size](https://img.shields.io/badge/core-2.44KB-blue.svg)](scripts/check-size.js)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lume-js",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Minimal reactive state management using only standard JavaScript and HTML - no custom syntax, no build step required",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary

- Bumps version `2.0.1 → 2.1.0` in `package.json` and `README.md`
- Adds `[2.1.0]` section to `CHANGELOG.md` covering all commits since v2.0.1
- Creates `RELEASE.md` with user-facing release notes and upgrade guide

No source code changes in this PR — all feature commits (`981f6a4`, `35f6fae`) are already on `main`. This PR is the release bookkeeping only.

## Why minor (2.1.0, not 2.0.2)

Two `feat` commits introduce new addons API surface (`create()` return value + error isolation in `repeat()`). Semver minor bump is required.
