### PR TITLE
chore(release): prepare v2.2.0

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build library
+        run: npm run build
+
       - name: Build site assets
         run: node scripts/build-site-assets.js
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: npm publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate (build + size + complexity + lint + typecheck + coverage)
+        run: npm run validate
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [2.2.0] - 2026-05-09
+
+### Added
+
+- **`className` handler** (`lume-js/handlers`) — `data-classname="key"` sets `el.className = val`. Use when reactive state holds a computed class string. Import: `import { className } from 'lume-js/handlers'`.
+- **`watch({ immediate: false })`** — pass `{ immediate: false }` as the fourth argument to skip the initial callback and only fire on future changes.
+- **`choosing-reactive-primitives` guide** (`docs/guides/choosing-reactive-primitives.md`) — when to use `effect` vs `computed` vs `watch`.
+- **Core benchmark suite** (`scripts/bench-core.js`) — microbenchmarks for state, effect, bindDom, and repeat.
+
+### Fixed
+
+- **`preview:site` styles** — added `--base /` to the `vite preview` command so asset paths match the build step's `--base /` override. Previously styles and scripts 404'd in local preview.
+- **CI coverage reporter** — removed invalid `--reporter` CLI flags that crashed vitest at startup; reporters are now configured exclusively in `vitest.config.js`.
+- **CI size-check JSON parse** — base-branch size comparison now handles the old check-size.js output format gracefully.
+
+### Refactor
+
+- **Handler source split** — `src/handlers/index.js` monolith split into one file per handler. Bundle output is unchanged.
+
+### CI
+
+- **Coverage gate** — `vitest --coverage` enforces 100% statements, branches, functions, and lines on every PR.
+- **Bundle size gate** — budgets now enforced on self-contained CDN builds (`index.min.mjs` ≤ 3 KB, `addons.min.mjs` ≤ 6 KB, `handlers.min.mjs` ≤ 2 KB, `lume.global.js` ≤ 8 KB). Size diff posted as PR comment.
+- **Cyclomatic complexity gate** — max CC ≤ 10 per function, MI ≥ 50 per file (acorn AST walk).
+- **Cognitive complexity gate** — `sonarjs/cognitive-complexity` ≤ 15 per function via ESLint.
+- **npm publish workflow** — publishing to npm now automated on GitHub Release creation (requires `NPM_TOKEN` secret).
+
+### Documentation
+
+- `README.md` — added `htmlAttrs()` to handler table, updated version to v2.2.0, corrected core size badge to 2.09 KB (now measured from `dist/index.min.mjs`).
+- `docs/guides/handlers.md` — documented `boolAttr`, `ariaAttr`, `className`, and `htmlAttrs()`.
+- `CONTRIBUTING.md` — updated project structure, corrected size budget, added CI gates table.
+- **Dev process templates** — `.github/pull_request_template.md`, `COMMIT_CHECKLIST.md`, `RELEASE_CHECKLIST.md`, `RELEASE_TEMPLATE.md`.
+
+### Tests
+
+348 tests passing (from 339 in v2.1.0) | 9 new tests for `className` and `watch({ immediate: false })`
+
+100% coverage: statements, branches, functions, lines across all 29 source files.
+
+---
+
 ## [2.1.0] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 Minimal reactive state management using only standard JavaScript and HTML. No custom syntax, no build step required, no framework lock-in.
 
-> **Current Release:** v2.1.0
+> **Current Release:** v2.2.0
 > Install: `npm install lume-js`  
 > Bundle size: ~2.09KB gzipped | 348 tests passing
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-2.1.0-orange.svg)](package.json)
+[![Version](https://img.shields.io/badge/version-2.2.0-orange.svg)](package.json)
 [![Tests](https://img.shields.io/badge/tests-348%20passing-brightgreen.svg)](tests/)
 [![Size](https://img.shields.io/badge/core-2.09KB-blue.svg)](scripts/check-size.js)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lume-js",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Minimal reactive state management using only standard JavaScript and HTML - no custom syntax, no build step required",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",

--- a/scripts/build-site-assets.js
+++ b/scripts/build-site-assets.js
@@ -44,27 +44,34 @@ function replacePlaceholders(filePath) {
 }
 
 async function computeMetrics() {
-  // Core gzipped size
-  const srcDir = path.join(rootDir, 'src');
-  const coreDir = path.join(srcDir, 'core');
-  const coreFiles = [];
-  async function scan(dir) {
-    for (const entry of await readdir(dir, { withFileTypes: true })) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) await scan(fullPath);
-      else if (entry.isFile() && path.extname(entry.name) === '.js') coreFiles.push(fullPath);
+  // Core gzipped size — read from the self-contained CDN build (dist/index.min.mjs).
+  // This matches the badge in README and the budget enforced by check-size.js.
+  // Requires `npm run build` to have run first; falls back to src/core/ scan if dist is missing.
+  let sizeKb;
+  const indexMinPath = path.join(rootDir, 'dist', 'index.min.mjs');
+  if (fs.existsSync(indexMinPath)) {
+    const content = await readFile(indexMinPath);
+    const gz = await gzipAsync(content);
+    sizeKb = (gz.length / 1024).toFixed(2);
+  } else {
+    const coreDir = path.join(rootDir, 'src', 'core');
+    const coreFiles = [];
+    async function scan(dir) {
+      for (const entry of await readdir(dir, { withFileTypes: true })) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) await scan(fullPath);
+        else if (entry.isFile() && path.extname(entry.name) === '.js') coreFiles.push(fullPath);
+      }
     }
+    await scan(coreDir);
+    let totalGzipped = 0;
+    for (const file of coreFiles) {
+      const code = await readFile(file, 'utf-8');
+      const minified = await minify(code, { compress: { passes: 2, unsafe: true, unsafe_comps: true, unsafe_methods: true }, mangle: { toplevel: true }, format: { comments: false } });
+      totalGzipped += (await gzipAsync(Buffer.from(minified.code))).length;
+    }
+    sizeKb = (totalGzipped / 1024).toFixed(2);
   }
-  await scan(coreDir);
-
-  let totalGzipped = 0;
-  for (const file of coreFiles) {
-    const code = await readFile(file, 'utf-8');
-    const minified = await minify(code, { compress: { passes: 2, unsafe: true, unsafe_comps: true, unsafe_methods: true }, mangle: { toplevel: true }, format: { comments: false } });
-    const gzipped = await gzipAsync(Buffer.from(minified.code));
-    totalGzipped += gzipped.length;
-  }
-  const sizeKb = (totalGzipped / 1024).toFixed(2);
 
   // Test count
   let testCount = 0;


### PR DESCRIPTION
## Summary

Version bump to 2.2.0, CHANGELOG entry, README version badge, and automated npm publish workflow. All feature code is already on `main` from the `feat/api-improvements` branch.

---

## Changes

- `package.json` — version `2.1.0` → `2.2.0`
- `CHANGELOG.md` — added v2.2.0 entry (features, fixes, CI, docs, tests)
- `README.md` — version badge `2.1.0` → `2.2.0`
- `.github/workflows/publish.yml` — new workflow: publishes to npm automatically when a GitHub Release is created (requires `NPM_TOKEN` secret)

---

## Pre-merge checklist

- [x] `npm run validate` passes — build, size, complexity, lint, typecheck, coverage
- [x] `package.json` version is `2.2.0`
- [x] `CHANGELOG.md` has the v2.2.0 section
- [x] `README.md` version badge updated
- [x] `NPM_TOKEN` secret set in repo Settings → Secrets → Actions