### PR TITLE
fix(gh-pages): use @latest CDN tag to prevent 404 during merge→publish window

### DIFF
--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -84,7 +84,8 @@
   <script src="https://cdn.jsdelivr.net/npm/marked@4/marked.min.js" defer></script>
 
   <!-- Lume.js global build — sets window.Lume; loaded in parallel with the site bundle -->
-  <script src="https://cdn.jsdelivr.net/npm/lume-js@__LUME_VERSION__/dist/lume.global.js" defer></script>
+  <!-- @latest always resolves to the last published stable release, preventing 404s during the merge→publish window -->
+  <script src="https://cdn.jsdelivr.net/npm/lume-js@latest/dist/lume.global.js" defer></script>
 
   <!-- FOUC prevention: apply saved theme before first paint -->
   <script>
@@ -104,9 +105,9 @@
   <script type="importmap">
   {
     "imports": {
-      "lume-js":          "https://cdn.jsdelivr.net/npm/lume-js@__LUME_VERSION__/dist/index.min.mjs",
-      "lume-js/addons":   "https://cdn.jsdelivr.net/npm/lume-js@__LUME_VERSION__/dist/addons.min.mjs",
-      "lume-js/handlers": "https://cdn.jsdelivr.net/npm/lume-js@__LUME_VERSION__/dist/handlers.min.mjs"
+      "lume-js":          "https://cdn.jsdelivr.net/npm/lume-js@latest/dist/index.min.mjs",
+      "lume-js/addons":   "https://cdn.jsdelivr.net/npm/lume-js@latest/dist/addons.min.mjs",
+      "lume-js/handlers": "https://cdn.jsdelivr.net/npm/lume-js@latest/dist/handlers.min.mjs"
     }
   }
   </script>


### PR DESCRIPTION
## Problem

After the release prep merged (`package.json` → `2.2.0`), the GH Pages build replaced `__LUME_VERSION__` in the CDN URLs with `2.2.0`. Since `lume-js@2.2.0` isn't on npm yet, the CDN returns 404, `window.Lume` is never set, and the site crashes:

```
Uncaught TypeError: Cannot destructure property 'state' of 'window.Lume' as it is undefined.
```
## Fix

Use `@latest` for the `lume.global.js` script tag and the import map. `@latest` always resolves to the last stable published release — the site stays functional in the gap between merge and npm publish. Once 2.2.0 is published, `@latest` automatically resolves to it.

The version *display text* (`v__LUME_VERSION__` in the UI) is unchanged and correctly shows `2.2.0`.

## Files changed

- `gh-pages/index.html` — `lume-js@__LUME_VERSION__` → `lume-js@latest` in the `<script>` tag and import map