### PR TITLE
docs: add missing handler/addon API docs and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ import { computed, watch, repeat } from 'lume-js/addons';
 | `computed(fn)` | Derive a read-only value from state to consume *outside* the store (templates, display logic) |
 | `watch(store, key, fn)` | React to a *specific* key changing — DOM updates, analytics, syncing external state |
 | `repeat(container, store, key, opts)` | Render a keyed list with element reuse (no full re-render on change) |
+| `createCleanupGroup()` | Collect multiple cleanup/unsubscribe functions and dispose them all at once |
+| `hydrateState(selector?)` | Read initial state from a `<script type="application/json">` tag (SSR hydration) |
 
 **Quick rule:** `effect` for writing back into state → `computed` for reading outside state → `watch` for observing a single key → `repeat` for arrays in the DOM.
 
@@ -240,9 +242,11 @@ Full documentation is available in the [docs/](docs/) directory:
     - [effect()](docs/api/core/effect.md) — Reactive effects
     - [Handlers](docs/api/core/handlers.md) — Extensible attribute handlers
     - [Plugins](docs/api/core/plugins.md) — State extension system
-    - [Addons](docs/api/addons/computed.md) — computed, watch, repeat, debug
+    - [Addons](docs/api/addons/computed.md) — computed, watch, repeat, createCleanupGroup, hydrateState
 - **Guides**
     - [Choosing reactive primitives](docs/guides/choosing-reactive-primitives.md) — when to use effect vs computed vs watch
+    - [Cleanup & Disposal](docs/guides/cleanup-and-dispose.md) — tearing down effects, bindings, and subscriptions
+    - [SSR & Hydration](docs/guides/ssr-hydration.md) — server-rendered HTML with reactive hydration
 - **Design**
     - [Design Decisions](docs/design/design-decisions.md)
 

--- a/docs/api/addons/createCleanupGroup.md
+++ b/docs/api/addons/createCleanupGroup.md
@@ -1,0 +1,73 @@
+# createCleanupGroup()
+
+Creates a cleanup group that collects multiple cleanup/unsubscribe functions and disposes them all at once.
+
+## Signature
+
+```ts
+function createCleanupGroup(): {
+  add(fn: () => void): void;
+  dispose(): void;
+}
+```
+
+Imported from `lume-js/addons`.
+
+## Returns
+
+An object with:
+- `add(fn)` — Registers a cleanup function. Non-functions are silently ignored.
+- `dispose()` — Calls all registered cleanup functions in reverse order, then clears the group.
+
+## Description
+
+`createCleanupGroup` solves the problem of tracking many cleanup functions across a component or view lifecycle. Each Lume primitive returns an unsubscribe/cleanup function — `bindDom`, `effect`, `watch`, `computed`, `store.$subscribe`. Instead of keeping references to each individually, add them to a group and call `dispose()` once.
+
+```js
+import { state, bindDom, effect } from 'lume-js';
+import { createCleanupGroup, watch } from 'lume-js/addons';
+
+const store = state({ name: 'World', count: 0 });
+const group = createCleanupGroup();
+
+group.add(bindDom(document.body, store));
+group.add(effect(() => { store.doubled = store.count * 2; }));
+group.add(watch(store, 'count', val => localStorage.setItem('count', val)));
+
+// Later — dispose everything at once
+group.dispose();
+```
+
+## Component teardown
+
+The most common use case is tearing down all reactivity when a view or component is removed:
+
+```js
+function mountUserCard(container, store) {
+  const group = createCleanupGroup();
+
+  group.add(bindDom(container, store));
+  group.add(store.$subscribe('profile', render));
+
+  return () => group.dispose(); // return teardown function
+}
+
+const teardown = mountUserCard(el, store);
+// When the component unmounts:
+teardown();
+```
+
+## Error handling
+
+Errors thrown by individual cleanup functions are caught and swallowed so that one broken cleanup does not prevent the others from running.
+
+## See also
+
+- [effect()](../core/effect.md)
+- [watch()](watch.md)
+- [bindDom()](../core/bindDom.md)
+- [Cleanup & Disposal guide](../../guides/cleanup-and-dispose.md)
+
+---
+
+**← Previous: [computed()](computed.md)** | **Next: [hydrateState()](hydrateState.md) →**

--- a/docs/api/addons/hydrateState.md
+++ b/docs/api/addons/hydrateState.md
@@ -1,0 +1,79 @@
+# hydrateState()
+
+Reads initial state from a `<script type="application/json">` element embedded in server-rendered HTML.
+
+## Signature
+
+```ts
+function hydrateState(selector?: string): object
+```
+
+Imported from `lume-js/addons`.
+
+## Parameters
+
+- `selector` — CSS selector for the script element. Defaults to `'#__LUME_DATA__'`.
+
+## Returns
+
+The parsed JSON object from the selected element, or an empty object `{}` if the element is not found or the JSON is invalid.
+
+## Description
+
+`hydrateState` enables SSR hydration: the server embeds the page's initial data as JSON in the HTML, and the client reads it to initialize reactive state without a separate API request.
+
+**Server (any language/framework):**
+```html
+<script id="__LUME_DATA__" type="application/json">
+  {"title": "Welcome", "user": "Ada", "count": 42}
+</script>
+```
+
+**Client:**
+```js
+import { state, bindDom } from 'lume-js';
+import { hydrateState } from 'lume-js/addons';
+
+const store = state(hydrateState());
+bindDom(document.body, store);
+```
+
+The store is initialized with `{ title: 'Welcome', user: 'Ada', count: 42 }` immediately — no async, no flash of empty content.
+
+## Custom selector
+
+Use a different selector when embedding multiple data blocks on one page:
+
+```html
+<script id="sidebar-data" type="application/json">{"open": false}</script>
+<script id="cart-data"    type="application/json">{"items": [], "total": 0}</script>
+```
+
+```js
+const sidebar = state(hydrateState('#sidebar-data'));
+const cart    = state(hydrateState('#cart-data'));
+```
+
+## Safe fallback
+
+`hydrateState` always returns an object. If the selector matches nothing, or the JSON is malformed, you get `{}` — which merges cleanly with default state:
+
+```js
+const store = state({
+  count: 0,          // default
+  ...hydrateState(), // server overrides
+});
+```
+
+## Non-browser environments
+
+When `document` is not defined (Node.js, Workers), `hydrateState` returns `{}` safely.
+
+## See also
+
+- [state()](../core/state.md)
+- [createCleanupGroup()](createCleanupGroup.md)
+
+---
+
+**← Previous: [createCleanupGroup()](createCleanupGroup.md)** | **Next: [repeat()](repeat.md) →**

--- a/docs/api/handlers/ariaAttr.md
+++ b/docs/api/handlers/ariaAttr.md
@@ -1,0 +1,102 @@
+# ariaAttr(name)
+
+Creates a handler that sets an ARIA attribute to `"true"` or `"false"` based on a store value.
+
+## Signature
+
+```ts
+function ariaAttr(name: string): { attr: string; apply(el: HTMLElement, val: any): void }
+```
+
+## Import
+
+```js
+import { ariaAttr } from 'lume-js/handlers';
+```
+
+## Parameters
+
+- `name` — The ARIA attribute name, with or without the `aria-` prefix (e.g. `'pressed'` or `'aria-pressed'`).
+
+## Returns
+
+A handler object `{ attr: 'data-aria-<name>', apply }` for use in `bindDom`'s `handlers` option.
+
+## Usage
+
+```js
+import { state, bindDom } from 'lume-js';
+import { ariaAttr } from 'lume-js/handlers';
+
+const store = state({ menuOpen: false, selected: true });
+
+bindDom(document.body, store, {
+  handlers: [ariaAttr('expanded'), ariaAttr('selected')]
+});
+```
+
+```html
+<button data-aria-expanded="menuOpen">Menu</button>
+<li data-aria-selected="selected" role="option">Option A</li>
+```
+
+When `store.menuOpen` is `false`, `aria-expanded="false"` is set on the button. When truthy, `aria-expanded="true"`.
+
+## Behavior
+
+| Value | Effect |
+|-------|--------|
+| Truthy | `el.setAttribute('aria-<name>', 'true')` |
+| Falsy | `el.setAttribute('aria-<name>', 'false')` |
+
+The attribute is always present on the element — it's set to either `"true"` or `"false"`, never removed. This is correct behavior for boolean ARIA states.
+
+## Built-in ARIA Attributes
+
+`bindDom` has built-in handlers for the most common ARIA attributes:
+
+| Attribute | Built-in |
+|-----------|----------|
+| `aria-expanded` | `data-aria-expanded` |
+| `aria-hidden` | `data-aria-hidden` |
+
+Use `ariaAttr` for ARIA state attributes not covered by the built-ins (`pressed`, `selected`, `disabled`, `checked`, `invalid`, etc.).
+
+## ariaAttr vs stringAttr for ARIA
+
+`ariaAttr` coerces values to `"true"`/`"false"` — use it for ARIA *boolean state* attributes.
+
+For ARIA *string/token* attributes (e.g. `aria-live`, `aria-label`, `aria-sort`), use `stringAttr('aria-live')` instead, which passes the value through as a string.
+
+```js
+import { ariaAttr, stringAttr } from 'lume-js/handlers';
+
+bindDom(root, store, {
+  handlers: [
+    ariaAttr('pressed'),          // aria-pressed="true"/"false"
+    stringAttr('aria-live'),      // aria-live="polite" (string value)
+    stringAttr('aria-label'),     // aria-label="Close dialog"
+  ]
+});
+```
+
+## Presets
+
+The `a11yHandlers` preset includes common ARIA boolean state attributes:
+
+```js
+import { a11yHandlers } from 'lume-js/handlers';
+// equivalent to: [ariaAttr('pressed'), ariaAttr('selected'), ariaAttr('disabled')]
+```
+
+## See also
+
+- [boolAttr](boolAttr.md)
+- [stringAttr](stringAttr.md)
+- [htmlAttrs()](htmlAttrs.md)
+- [Handlers guide](../../guides/handlers.md)
+- [bindDom()](../core/bindDom.md)
+
+---
+
+**← Previous: [boolAttr](boolAttr.md)** | **Next: [stringAttr](stringAttr.md) →**

--- a/docs/api/handlers/boolAttr.md
+++ b/docs/api/handlers/boolAttr.md
@@ -1,0 +1,87 @@
+# boolAttr(name)
+
+Creates a handler that toggles any HTML boolean attribute reactively.
+
+## Signature
+
+```ts
+function boolAttr(name: string): { attr: string; apply(el: HTMLElement, val: any): void }
+```
+
+## Import
+
+```js
+import { boolAttr } from 'lume-js/handlers';
+```
+
+## Parameters
+
+- `name` — The HTML attribute name (e.g. `'readonly'`, `'open'`, `'contenteditable'`).
+
+## Returns
+
+A handler object `{ attr: 'data-<name>', apply }` for use in `bindDom`'s `handlers` option.
+
+## Usage
+
+```js
+import { state, bindDom } from 'lume-js';
+import { boolAttr } from 'lume-js/handlers';
+
+const store = state({ editable: false, panelOpen: true });
+
+bindDom(document.body, store, {
+  handlers: [boolAttr('contenteditable'), boolAttr('open')]
+});
+```
+
+```html
+<div data-contenteditable="editable">Click to edit</div>
+<details data-open="panelOpen">
+  <summary>Details</summary>
+  <p>Content</p>
+</details>
+```
+
+## Behavior
+
+Uses `el.toggleAttribute(name, Boolean(val))`. A truthy value sets the attribute; a falsy value removes it.
+
+| Value | Effect |
+|-------|--------|
+| Truthy | `el.setAttribute(name, '')` — attribute present |
+| Falsy (`false`, `null`, `0`, `''`) | `el.removeAttribute(name)` — attribute absent |
+
+## Built-in Boolean Attributes
+
+`bindDom` has built-in handlers for the most common boolean attributes — you don't need `boolAttr` for these:
+
+| Attribute | Built-in |
+|-----------|----------|
+| `hidden` | `data-hidden` |
+| `disabled` | `data-disabled` |
+| `checked` | `data-checked` |
+| `required` | `data-required` |
+
+Use `boolAttr` for any boolean attribute not covered by the built-ins (e.g. `readonly`, `open`, `contenteditable`, `multiple`, `novalidate`).
+
+## Presets
+
+The `formHandlers` preset includes `boolAttr('readonly')`:
+
+```js
+import { formHandlers } from 'lume-js/handlers';
+// equivalent to: [boolAttr('readonly')]
+```
+
+## See also
+
+- [ariaAttr](ariaAttr.md)
+- [stringAttr](stringAttr.md)
+- [htmlAttrs()](htmlAttrs.md)
+- [Handlers guide](../../guides/handlers.md)
+- [bindDom()](../core/bindDom.md)
+
+---
+
+**← Previous: [className](className.md)** | **Next: [ariaAttr](ariaAttr.md) →**

--- a/docs/api/handlers/className.md
+++ b/docs/api/handlers/className.md
@@ -1,0 +1,60 @@
+# className
+
+Replaces an element's full class string with a store value.
+
+## Attribute
+
+`data-classname="key"`
+
+## Import
+
+```js
+import { className } from 'lume-js/handlers';
+```
+
+## Usage
+
+```js
+import { state, bindDom } from 'lume-js';
+import { className } from 'lume-js/handlers';
+
+const store = state({ cardStyle: 'card card--featured' });
+
+bindDom(document.body, store, { handlers: [className] });
+```
+
+```html
+<div data-classname="cardStyle">Featured</div>
+```
+
+When `store.cardStyle` changes, `el.className` is replaced with the new value. If the value is falsy (`null`, `undefined`, `false`, `''`), the class string is set to `''`.
+
+## Behavior
+
+| Value | Effect |
+|-------|--------|
+| `'card card--featured'` | `el.className = 'card card--featured'` |
+| `''` / falsy | `el.className = ''` (all classes removed) |
+
+`className` replaces the entire class string on every update. Any classes added outside reactive state will be lost.
+
+## Compared to `classToggle`
+
+| | `className` | `classToggle` |
+|--|-------------|---------------|
+| Controls | Full class string | Individual CSS classes |
+| Use when | Class string comes from state | Toggling one class on/off |
+| Static classes safe | ❌ (overwritten) | ✅ (other classes preserved) |
+
+Use `className` when the entire class string is computed. Use `classToggle` to flip individual classes based on boolean state while preserving others.
+
+## See also
+
+- [classToggle](classToggle.md)
+- [show](show.md)
+- [Handlers guide](../../guides/handlers.md)
+- [bindDom()](../core/bindDom.md)
+
+---
+
+**← Previous: [show](show.md)** | **Next: [classToggle](classToggle.md) →**

--- a/docs/api/handlers/htmlAttrs.md
+++ b/docs/api/handlers/htmlAttrs.md
@@ -1,0 +1,87 @@
+# htmlAttrs()
+
+One-import preset that enables reactive handlers for all standard HTML and ARIA attributes.
+
+## Signature
+
+```ts
+function htmlAttrs(): Array<{ attr: string; apply(el: HTMLElement, val: any): void }>
+```
+
+## Import
+
+```js
+import { htmlAttrs } from 'lume-js/handlers';
+```
+
+## Returns
+
+A flat array of handler objects — pass directly to `bindDom`'s `handlers` option.
+
+## Usage
+
+```js
+import { state, bindDom } from 'lume-js';
+import { htmlAttrs } from 'lume-js/handlers';
+
+const store = state({
+  profileUrl: '/user/alice',
+  avatarSrc: '/img/alice.jpg',
+  panelOpen: false,
+  isPressed: false,
+  liveRegion: 'polite',
+});
+
+bindDom(document.body, store, { handlers: htmlAttrs() });
+```
+
+```html
+<a data-href="profileUrl">Profile</a>
+<img data-src="avatarSrc" data-alt="username">
+<details data-open="panelOpen">
+  <summary>Details</summary>
+</details>
+<button data-aria-pressed="isPressed">Toggle</button>
+<div role="status" data-aria-live="liveRegion">Updates here</div>
+```
+
+## What's Included
+
+`htmlAttrs()` includes handlers for three categories:
+
+**Boolean HTML attributes** — toggled present/absent via `toggleAttribute`:
+`readonly`, `open`, `novalidate`, `formnovalidate`, `multiple`, `autofocus`, `autoplay`, `controls`, `loop`, `muted`, `defer`, `async`, `reversed`, `selected`, `inert`, `allowfullscreen`
+
+**String HTML attributes** — set as strings, removed when `null`/`undefined`:
+`href`, `src`, `alt`, `title`, `placeholder`, `action`, `method`, `target`, `rel`, `type`, `name`, `role`, `lang`, `tabindex`, `pattern`, `min`, `max`, `step`, `minlength`, `maxlength`, `width`, `height`, `for`, `form`, `accept`, `autocomplete`, `loading`, `decoding`, `inputmode`, `enterkeyhint`, `draggable`, `contenteditable`, `spellcheck`, `translate`, `dir`, `id`, `poster`, `preload`, `download`, `media`, `sizes`, `srcset`, `colspan`, `rowspan`, `scope`, `headers`, `wrap`, `sandbox`, and more.
+
+**ARIA attributes** — both boolean states (`aria-pressed`, `aria-selected`, `aria-disabled`, …) and string/token attributes (`aria-live`, `aria-label`, `aria-sort`, …).
+
+Also includes the `show` handler (`data-show`).
+
+## When to use
+
+`htmlAttrs()` is the simplest choice when you want broad coverage without importing individual handlers. It covers nearly every standard HTML and ARIA attribute reactively.
+
+For precise control over bundle size, import only the handlers you actually use:
+
+```js
+import { boolAttr, stringAttr, ariaAttr } from 'lume-js/handlers';
+
+bindDom(root, store, {
+  handlers: [boolAttr('open'), stringAttr('href'), ariaAttr('expanded')]
+});
+```
+
+## See also
+
+- [boolAttr](boolAttr.md)
+- [ariaAttr](ariaAttr.md)
+- [stringAttr](stringAttr.md)
+- [show](show.md)
+- [Handlers guide](../../guides/handlers.md)
+- [bindDom()](../core/bindDom.md)
+
+---
+
+**← Previous: [ariaAttr](ariaAttr.md)** | **Next: [show](show.md) →**


### PR DESCRIPTION
## Summary

- Adds 6 missing API documentation pages shipped with v2.2.0 but never documented:
  - `docs/api/addons/createCleanupGroup.md`
  - `docs/api/addons/hydrateState.md`
  - `docs/api/handlers/className.md`
  - `docs/api/handlers/boolAttr.md`
  - `docs/api/handlers/ariaAttr.md`
  - `docs/api/handlers/htmlAttrs.md`
- Updates README addons table to include `createCleanupGroup` and `hydrateState`
- Adds links to `cleanup-and-dispose` and `ssr-hydration` guides in the README docs section

## Test plan

- [x] All 6 new doc pages render correctly (correct markdown, working cross-links)
- [x] README addons table shows all 6 entries including the two new ones
- [x] README docs section links resolve correctly