### PR TITLE
chore(release): Lume.js v2.2.1 — security hardening patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2.2.1] - 2026-05-12
+
+### Security
+
+- **`state()` — prototype pollution hardening:** Proxy `set` trap now blocks writes to `__proto__`, `constructor`, and `prototype` keys, with a console warning. This prevents attackers from modifying object prototypes through reactive state mutations.
+- **`state()` — subscriber DoS protection:** Per-key subscriber lists are now capped at 1000 entries. Additional subscribers are silently dropped with a warning, preventing memory exhaustion from unbounded subscription accumulation.
+- **`stringAttr()` — dangerous URI scheme sanitization:** URI-bearing attributes (`href`, `src`, `action`, `srcset`, `poster`, `formaction`) now strip values containing `javascript:`, `vbscript:`, or `data:text/html` schemes. This prevents `javascript:` URI injection via reactive attribute bindings.
+- **`hydrateState()` — DOM clobbering mitigation:** Now validates that the selected element is a `<script type="application/json">` before parsing. Non-script elements or scripts with wrong types are rejected. Also accepts an optional `validate` callback for schema enforcement.
+- **`withPlugins()` — plugin freeze defense-in-depth:** Plugin objects are `Object.freeze()`'d after `onInit` runs, preventing post-registration hook mutation.
+
+### Documentation
+
+- **Security notes added to all affected APIs:** `@security` JSDoc tags added to `withReadObserver`, `computed`, `bindDom`, and `hydrateState` documenting trust models and known limitations.
+
+### Tests
+
+- **355 tests passing** (from 348 in v2.2.0) | 7 new tests
+  - Prototype-polluting key blocking (`state.test.js`)
+  - Subscriber limit enforcement (`state.test.js`)
+  - Dangerous URI scheme stripping (`handlers/index.test.js`)
+  - DOM clobbering rejection + schema validation (`hydrateState.test.js`)
+
+---
+
 ## [2.2.0] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
   <p>
     <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
     &nbsp;
-    <a href="package.json"><img src="https://img.shields.io/badge/version-2.2.0-orange.svg" alt="v2.2.0"></a>
+    <a href="package.json"><img src="https://img.shields.io/badge/version-2.2.1-orange.svg" alt="v2.2.1"></a>
     &nbsp;
-    <a href="tests/"><img src="https://img.shields.io/badge/tests-348%20passing-brightgreen.svg" alt="348 tests"></a>
+    <a href="tests/"><img src="https://img.shields.io/badge/tests-355%20passing-brightgreen.svg" alt="355 tests"></a>
     &nbsp;
-    <a href="scripts/check-size.js"><img src="https://img.shields.io/badge/core-2.09KB%20gzipped-blue.svg" alt="2.09KB"></a>
+    <a href="scripts/check-size.js"><img src="https://img.shields.io/badge/core-2.23KB%20gzipped-blue.svg" alt="2.23KB"></a>
   </p>
   <p><code>npm install lume-js</code></p>
 </div>
@@ -26,7 +26,7 @@
 |---------|---------|-----------|-----|-------|
 | Custom Syntax | ❌ No | ✅ `x-data` | ✅ `v-bind` | ✅ JSX |
 | Build Step | ❌ Optional | ❌ Optional | ⚠️ Recommended | ✅ Required |
-| Bundle Size | ~2.09KB | ~15KB | ~35KB | ~45KB |
+| Bundle Size | ~2.23KB | ~15KB | ~35KB | ~45KB |
 | HTML Validation | ✅ Pass | ⚠️ Warnings | ⚠️ Warnings | ❌ JSX |
 | Extensible Handlers | ✅ | ❌ Built-in only | ❌ Built-in only | N/A |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lume-js",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Minimal reactive state management using only standard JavaScript and HTML - no custom syntax, no build step required",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",

--- a/scripts/complexity.js
+++ b/scripts/complexity.js
@@ -231,12 +231,26 @@ const anyFailed = results.some(r => r.overBudget);
 
 // ── JSON output ───────────────────────────────────────────────────────────────
 
+function cleanNumbers(obj) {
+  if (typeof obj === 'number') {
+    const r = Math.round(obj * 100) / 100;
+    return r === 0 ? 0 : r;
+  }
+  if (Array.isArray(obj)) return obj.map(cleanNumbers);
+  if (obj && typeof obj === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(obj)) out[k] = cleanNumbers(v);
+    return out;
+  }
+  return obj;
+}
+
 if (isJson) {
-  console.log(JSON.stringify({
+  console.log(JSON.stringify(cleanNumbers({
     passed: !anyFailed,
     thresholds: { maxCC: MAX_CC, minMI: MIN_MI },
     files: results,
-  }, null, 2));
+  }), null, 2));
   process.exit(anyFailed ? 1 : 0);
 }
 

--- a/scripts/complexity.js
+++ b/scripts/complexity.js
@@ -134,6 +134,11 @@ function getFunctions(ast) {
 
 // ── File metrics ──────────────────────────────────────────────────────────────
 
+function round(num, places) {
+  const r = parseFloat(num.toFixed(places));
+  return r === 0 ? 0 : r;
+}
+
 function maintainabilityIndex(avgCC, loc) {
   if (loc < 1) return 100;
   const mi = (171 - 0.23 * avgCC - 16.2 * Math.log(loc)) * 100 / 171;
@@ -199,8 +204,8 @@ async function analyzeFile(filePath) {
     loc,
     funcs: funcs.length,
     maxCC,
-    avgCC: Math.round(avgCC * 10) / 10,
-    mi: Math.round(mi * 10) / 10,
+    avgCC: round(avgCC, 1),
+    mi: round(mi, 1),
     grade,
     overBudget: miViolation || violations.length > 0,
     violations,
@@ -232,10 +237,7 @@ const anyFailed = results.some(r => r.overBudget);
 // ── JSON output ───────────────────────────────────────────────────────────────
 
 function cleanNumbers(obj) {
-  if (typeof obj === 'number') {
-    const r = Math.round(obj * 100) / 100;
-    return r === 0 ? 0 : r;
-  }
+  if (typeof obj === 'number') return round(obj, 2);
   if (Array.isArray(obj)) return obj.map(cleanNumbers);
   if (obj && typeof obj === 'object') {
     const out = {};

--- a/src/addons/computed.js
+++ b/src/addons/computed.js
@@ -33,6 +33,11 @@ import { logError } from '../utils/log.js';
  * mutates a state property it depends on, the flush triggered by that
  * mutation is skipped to prevent an infinite microtask loop.
  *
+ * @security After each computation, a re-entry guard stays active until the
+ * next microtask. If a dependency changes synchronously during this window,
+ * the computed will not recompute until a subsequent microtask. This is
+ * intentional — it prevents infinite loops from self-mutating computeds.
+ *
  * @param {function} fn - Function that computes the value
  * @returns {object} Object with .value property and methods
  * 

--- a/src/addons/hydrateState.js
+++ b/src/addons/hydrateState.js
@@ -2,8 +2,16 @@
  * Reads initial state from a `<script type="application/json">` element
  * embedded in the server-rendered HTML. Useful for SSR / hydration patterns.
  *
+ * @security Hydration trusts the DOM. An attacker who can inject HTML before
+ * the legitimate script (DOM clobbering) can control the parsed data. The
+ * element must be a real `<script type="application/json">` tag; non-script
+ * elements are rejected. Use the optional `validate` parameter to enforce a
+ * schema (e.g., whitelist allowed keys) before passing to `state()`.
+ *
  * @param {string} [selector='#__LUME_DATA__'] - CSS selector for the script element
- * @returns {object} Parsed JSON object, or empty object if not found / invalid
+ * @param {function} [validate] - Optional validator: (data) => boolean. If it
+ *   returns false, hydrateState returns {} instead of the parsed data.
+ * @returns {object} Parsed JSON object, or empty object if not found / invalid / rejected
  *
  * @example
  * ```html
@@ -16,15 +24,35 @@
  * import { state } from 'lume-js';
  * import { hydrateState } from 'lume-js/addons';
  *
- * const store = state(hydrateState());
+ * // With optional schema validation
+ * const data = hydrateState('#__LUME_DATA__', d =>
+ *   typeof d.title === 'string' && typeof d.count === 'number'
+ * );
+ * const store = state(data);
  * ```
  */
-export function hydrateState(selector = '#__LUME_DATA__') {
+export function hydrateState(selector = '#__LUME_DATA__', validate) {
   const el = typeof document !== 'undefined' ? document.querySelector(selector) : null;
   if (!el) return {};
+
+  // Reject non-script elements or scripts without the correct type.
+  // This mitigates DOM clobbering where an attacker injects a matching
+  // element with a different tag name (e.g., a div or a script with
+  // a different type that would still match querySelector by id).
+  if (el.tagName !== 'SCRIPT' || el.type !== 'application/json') {
+    return {};
+  }
+
+  let data;
   try {
-    return JSON.parse(el.textContent);
+    data = JSON.parse(el.textContent);
   } catch {
     return {};
   }
+
+  if (typeof validate === 'function' && !validate(data)) {
+    return {};
+  }
+
+  return data;
 }

--- a/src/addons/withPlugins.js
+++ b/src/addons/withPlugins.js
@@ -24,6 +24,10 @@
  *   onNotify(key, value)             — called before subscribers are notified
  *   onSubscribe(key)                 — called when $subscribe is invoked
  *
+ * @security Plugins run with full application privilege. A plugin can read
+ * all state, alter any write, or suppress mutations. Only pass trusted objects.
+ * Plugin objects are frozen after registration to prevent post-init mutation.
+ *
  * @param {object} store - A reactive proxy from state()
  * @param {Array<object>} plugins - Array of plugin objects
  * @returns {Proxy} A new proxy wrapping the store with plugin behavior
@@ -33,13 +37,15 @@ import { logError } from '../utils/log.js';
 export function withPlugins(store, plugins = []) {
   if (!plugins.length) return store;
 
-  // Call onInit hooks once at wrap time
+  // Call onInit hooks once at wrap time, then freeze each plugin to prevent
+  // post-registration mutation of its hooks (defense-in-depth).
   for (const p of plugins) {
     try {
       p.onInit?.();
     } catch (e) {
       logError(`[Lume.js] Plugin "${p.name}" error in onInit:`, e);
     }
+    Object.freeze(p);
   }
 
   // Track pending notifications for onNotify hooks.

--- a/src/core/bindDom.js
+++ b/src/core/bindDom.js
@@ -24,6 +24,11 @@
  * Usage:
  *   import { bindDom } from "lume-js";
  *   const cleanup = bindDom(document.body, store);
+ *
+ * @security `data-bind` attribute values are resolved once at bind time and
+ * trusted as state path expressions. If an attacker can inject `data-bind`
+ * attributes into the DOM, they can subscribe to any reachable reactive state.
+ * Ensure your HTML is trusted or sanitize it before calling bindDom().
  */
 
 import { logWarn } from '../utils/log.js';

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -55,6 +55,12 @@ const readers = new Set();
  *
  * Internal API — used by effect.js for auto-tracking. May be stabilized
  * for third-party addons in a future release.
+ *
+ * @security The observer sees reads from ALL state instances within the same
+ * module instance, including nested scopes. Only pass trusted observer functions.
+ * A future scoped variant (e.g., scopedReadObserver(store, fn)) may limit
+ * observation to a single state instance.
+ *
  * @param {function} onRead - Called on each property access inside fn
  * @param {function} fn - The function to run under observation
  */

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -22,7 +22,7 @@
  *   unsub(); // cleanup
  */
 
-import { logError } from '../utils/log.js';
+import { logError, logWarn } from '../utils/log.js';
 
 // Per-state batching – each state object maintains its own microtask flush.
 // This keeps effects simple and aligned with Lume's minimal philosophy.
@@ -191,6 +191,8 @@ export function state(obj) {
     };
   };
 
+  const BLOCKED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
   const proxy = new Proxy(obj, {
     get(target, key) {
       // Skip effect tracking for internal meta methods (e.g. $subscribe)
@@ -211,6 +213,11 @@ export function state(obj) {
     },
 
     set(target, key, value) {
+      if (typeof key === 'string' && BLOCKED_KEYS.has(key)) {
+        logWarn(`[Lume.js state] Blocked write to reserved key "${key}"`);
+        return true;
+      }
+
       const oldValue = target[key];
 
       // Skip update if value unchanged - Object.is() handles NaN and -0 correctly
@@ -256,12 +263,18 @@ export function state(obj) {
     };
   };
 
+  const MAX_SUBSCRIBERS = 1000;
+
   obj.$subscribe = (key, fn) => {
     if (typeof fn !== 'function') {
       throw new Error('Subscriber must be a function');
     }
 
     if (!listeners[key]) listeners[key] = [];
+    if (listeners[key].length >= MAX_SUBSCRIBERS) {
+      logWarn(`[Lume.js state] Subscriber limit (${MAX_SUBSCRIBERS}) reached for key "${key}". New subscriber ignored.`);
+      return () => {};
+    }
     listeners[key].push(fn);
 
     // Call immediately with current value (NOT batched)

--- a/src/handlers/stringAttr.js
+++ b/src/handlers/stringAttr.js
@@ -5,12 +5,24 @@
  * @param {string} name - HTML attribute name (e.g., 'href', 'src', 'title')
  * @returns {{ attr: string, apply: function }}
  */
+
+const DANGEROUS_SCHEME = /^(javascript|vbscript|data\s*:\s*text\/html)/i;
+const URI_ATTRS = new Set(['href', 'src', 'action', 'srcset', 'poster', 'formaction']);
+
 export function stringAttr(name) {
   return {
     attr: `data-${name}`,
     apply(el, val) {
-      if (val == null) el.removeAttribute(name);
-      else el.setAttribute(name, String(val));
+      if (val == null) {
+        el.removeAttribute(name);
+        return;
+      }
+      const strVal = String(val);
+      if (URI_ATTRS.has(name) && DANGEROUS_SCHEME.test(strVal)) {
+        el.removeAttribute(name);
+        return;
+      }
+      el.setAttribute(name, strVal);
     }
   };
 }

--- a/tests/addons/hydrateState.test.js
+++ b/tests/addons/hydrateState.test.js
@@ -69,4 +69,63 @@ describe('hydrateState', () => {
       globalThis.document = originalDoc;
     }
   });
+
+  it('rejects non-script elements (DOM clobbering mitigation)', () => {
+    const el = document.createElement('div');
+    el.id = '__TEST_CLOBBER__';
+    document.body.appendChild(el);
+
+    try {
+      const result = hydrateState('#__TEST_CLOBBER__');
+      expect(result).toEqual({});
+    } finally {
+      el.remove();
+    }
+  });
+
+  it('rejects script elements with wrong type', () => {
+    const el = document.createElement('script');
+    el.id = '__TEST_WRONG_TYPE__';
+    el.type = 'text/javascript';
+    // No textContent — jsdom would try to execute it if it looked like JS.
+    // The type check rejects before JSON.parse is reached.
+    document.body.appendChild(el);
+
+    try {
+      const result = hydrateState('#__TEST_WRONG_TYPE__');
+      expect(result).toEqual({});
+    } finally {
+      el.remove();
+    }
+  });
+
+  it('accepts a validate function and rejects invalid data', () => {
+    const el = document.createElement('script');
+    el.id = '__TEST_VALIDATE__';
+    el.type = 'application/json';
+    el.textContent = '{"title":"Welcome","count":42}';
+    document.body.appendChild(el);
+
+    try {
+      // Validator requires both title (string) and count (number)
+      const validator = (d) => typeof d.title === 'string' && typeof d.count === 'number';
+
+      const result = hydrateState('#__TEST_VALIDATE__', validator);
+      expect(result).toEqual({ title: 'Welcome', count: 42 });
+
+      // Invalid data rejected by validator
+      const badEl = document.createElement('script');
+      badEl.id = '__TEST_VALIDATE_BAD__';
+      badEl.type = 'application/json';
+      badEl.textContent = '{"isAdmin": true}';
+      document.body.appendChild(badEl);
+
+      const badResult = hydrateState('#__TEST_VALIDATE_BAD__', validator);
+      expect(badResult).toEqual({});
+
+      badEl.remove();
+    } finally {
+      el.remove();
+    }
+  });
 });

--- a/tests/core/state.test.js
+++ b/tests/core/state.test.js
@@ -267,6 +267,37 @@ describe('state', () => {
     expect(isReactive(outer.inner)).toBe(true);
   });
 
+  it('blocks writes to prototype-polluting keys', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = state({ count: 0 });
+
+    store.__proto__ = { injected: true };
+    store.constructor = function Mal() {};
+    store.prototype = { hacked: true };
+
+    expect(store.count).toBe(0);
+    expect(Object.getPrototypeOf(store)).toBe(Object.prototype);
+
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+    warnSpy.mockRestore();
+  });
+
+  it('enforces a maximum number of subscribers per key', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const store = state({ x: 0 });
+
+    const unsubs = [];
+    for (let i = 0; i < 1002; i++) {
+      unsubs.push(store.$subscribe('x', () => {}));
+    }
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+
+    // Cleanup
+    unsubs.forEach(u => u());
+  });
+
   it('reactive brand symbol is present but not enumerable', () => {
     const store = state({ x: 1 });
     const brands = Object.getOwnPropertySymbols(store);

--- a/tests/handlers/index.test.js
+++ b/tests/handlers/index.test.js
@@ -346,6 +346,46 @@ describe('handlers module', () => {
 
       cleanup();
     });
+
+    it('removes href when value contains a dangerous URI scheme', async () => {
+      const root = setupDOM(`<div><a data-href="url">Link</a></div>`);
+      const store = state({ url: 'https://example.com' });
+
+      const cleanup = bindDom(root, store, { handlers: [stringAttr('href')] });
+      const link = root.querySelector('a');
+
+      expect(link.getAttribute('href')).toBe('https://example.com');
+
+      store.url = 'javascript:alert(1)';
+      await Promise.resolve();
+      expect(link.hasAttribute('href')).toBe(false);
+
+      store.url = 'vbscript:msgbox(1)';
+      await Promise.resolve();
+      expect(link.hasAttribute('href')).toBe(false);
+
+      store.url = 'data:text/html,<script>alert(1)</script>';
+      await Promise.resolve();
+      expect(link.hasAttribute('href')).toBe(false);
+
+      store.url = 'https://safe.example.com';
+      await Promise.resolve();
+      expect(link.getAttribute('href')).toBe('https://safe.example.com');
+
+      cleanup();
+    });
+
+    it('allows data:image URLs on src attributes', async () => {
+      const root = setupDOM(`<div><img data-src="img" /></div>`);
+      const store = state({ img: 'data:image/png;base64,abc123' });
+
+      const cleanup = bindDom(root, store, { handlers: [stringAttr('src')] });
+      const img = root.querySelector('img');
+
+      expect(img.getAttribute('src')).toBe('data:image/png;base64,abc123');
+
+      cleanup();
+    });
   });
 
   describe('custom handlers', () => {


### PR DESCRIPTION
## Release: v2.2.1 (Patch)

Security-focused patch release — no breaking changes, no new public APIs.

### Security Fixes
- **state()**: Block prototype-polluting keys (`__proto__`, [constructor](cci:1://file:///Users/sc/Documents/workspace/lume-js/tests/core/state.test.js:274:4-274:42), `prototype`) in Proxy [set](cci:1://file:///Users/sc/Documents/workspace/lume-js/src/core/state.js:220:4-238:5) trap
- **state()**: Cap per-key subscribers at 1000 to prevent client-side DoS
- **stringAttr()**: Strip `javascript:`, `vbscript:`, `data:text/html` from URI-bearing attributes
- **hydrateState()**: Validate element type (`<script type="application/json">`) and accept optional `validate` callback
- **withPlugins()**: `Object.freeze()` plugins after `onInit` to prevent post-registration hook mutation

### Documentation
- `@security` JSDoc notes added to [withReadObserver](cci:1://file:///Users/sc/Documents/workspace/lume-js/src/core/state.js:50:0-73:1), [computed](cci:1://file:///Users/sc/Documents/workspace/lume-js/src/addons/computed.js:24:0-164:1), [bindDom](cci:1://file:///Users/sc/Documents/workspace/lume-js/src/core/bindDom.js:69:0-127:1), and [hydrateState](cci:1://file:///Users/sc/Documents/workspace/lume-js/src/addons/hydrateState.js:0:0-57:1)

### Stats
- 355 tests passing (+7), 100% coverage maintained
- Core bundle: 2.23 KB gzipped (within 3 KB budget)

### Checklist
- [x] `npm run validate` passes (build, size, complexity, lint, typecheck, coverage)
- [x] CHANGELOG.md updated
- [x] README.md badges updated
- [x] Version bumped to 2.2.1