### PR TITLE
fix(core): apply subscriber cap to effect subscriptions, fail loudly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,21 @@
 
 ### Fixed
 
+- **`state()` — subscriber cap consistency:** the per-key 1000-listener cap
+  (added in 2.2.1) only applied to `$subscribe`; effect subscriptions bypassed
+  it entirely. Both paths now share one capped registration helper, and
+  hitting the cap logs a `console.error` (was a silent-ish warn) stating that
+  the listener will not receive updates.
 - **`effect()` — explicit-deps runs coalesced:** with `effect(fn, [[store, 'a', 'b']])`,
   changing N tracked keys in one tick re-ran the effect N times (auto-tracking
   mode already deduplicated). Explicit-deps notifications now coalesce into a
   single run per microtask, across keys and across stores, with a disposal
-  guard for runs pending at cleanup time. See [docs/changes/02](docs/changes/02-fix-explicit-deps-coalescing.md).
+  guard for runs pending at cleanup time.
 - **`effect()` — cross-store dependency tracking:** an effect reading the same
   property name on two different stores (e.g. `storeA.value` and
   `storeB.value`) only subscribed to the first store; mutations to the second
   store silently never re-ran the effect. Tracking is now keyed per store proxy
-  (`WeakMap<proxy, Set<key>>`). See [docs/changes/01](docs/changes/01-fix-effect-cross-store-tracking.md).
+  (`WeakMap<proxy, Set<key>>`).
 
 ---
 

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -176,25 +176,43 @@ export function state(obj) {
   const REACTIVE_BRAND = Symbol('lume.reactive');
   obj[REACTIVE_BRAND] = true;
 
-  // Defined once per state instance — not per property read — to avoid per-read closure allocation.
-  const registerEffect = (key, executeFn) => {
+  const MAX_SUBSCRIBERS = 1000;
+  const noopUnsubscribe = () => {};
+
+  /**
+   * Shared listener registration with a per-key cap (subscriber DoS
+   * protection). Applied identically to $subscribe callbacks and effect
+   * subscriptions so both paths degrade the same way: a loud console
+   * error and a no-op unsubscribe.
+   */
+  function addListener(key, fn, kind) {
     if (!listeners[key]) listeners[key] = [];
-
-    const callback = () => {
-      pendingEffects.add(executeFn);
-    };
-
-    listeners[key].push(callback);
-
+    if (listeners[key].length >= MAX_SUBSCRIBERS) {
+      logError(
+        `[Lume.js state] Subscriber limit (${MAX_SUBSCRIBERS}) reached for key "${String(key)}". ` +
+        `${kind} ignored — it will NOT receive updates. ` +
+        'This usually means subscriptions are created in a loop without cleanup.'
+      );
+      return noopUnsubscribe;
+    }
+    listeners[key].push(fn);
     return () => {
       if (listeners[key]) {
-        const idx = listeners[key].indexOf(callback);
+        const idx = listeners[key].indexOf(fn);
         if (idx !== -1) {
           listeners[key].splice(idx, 1);
           if (listeners[key].length === 0) delete listeners[key];
         }
       }
     };
+  }
+
+  // Defined once per state instance — not per property read — to avoid per-read closure allocation.
+  const registerEffect = (key, executeFn) => {
+    const callback = () => {
+      pendingEffects.add(executeFn);
+    };
+    return addListener(key, callback, 'Effect subscription');
   };
 
   const BLOCKED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
@@ -269,33 +287,20 @@ export function state(obj) {
     };
   };
 
-  const MAX_SUBSCRIBERS = 1000;
-
   obj.$subscribe = (key, fn) => {
     if (typeof fn !== 'function') {
       throw new Error('Subscriber must be a function');
     }
 
-    if (!listeners[key]) listeners[key] = [];
-    if (listeners[key].length >= MAX_SUBSCRIBERS) {
-      logWarn(`[Lume.js state] Subscriber limit (${MAX_SUBSCRIBERS}) reached for key "${key}". New subscriber ignored.`);
-      return () => {};
-    }
-    listeners[key].push(fn);
+    const unsubscribe = addListener(key, fn, 'New subscriber');
+
+    // Over the cap: listener was not added, skip the immediate call too
+    if (unsubscribe === noopUnsubscribe) return unsubscribe;
 
     // Call immediately with current value (NOT batched)
     fn(proxy[key]);
 
-    // Return unsubscribe function
-    return () => {
-      if (listeners[key]) {
-        const idx = listeners[key].indexOf(fn);
-        if (idx !== -1) {
-          listeners[key].splice(idx, 1);
-          if (listeners[key].length === 0) delete listeners[key];
-        }
-      }
-    };
+    return unsubscribe;
   };
 
   return proxy;

--- a/tests/core/state.test.js
+++ b/tests/core/state.test.js
@@ -282,8 +282,8 @@ describe('state', () => {
     warnSpy.mockRestore();
   });
 
-  it('enforces a maximum number of subscribers per key', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  it('enforces a maximum number of subscribers per key with a loud error', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const store = state({ x: 0 });
 
     const unsubs = [];
@@ -291,11 +291,48 @@ describe('state', () => {
       unsubs.push(store.$subscribe('x', () => {}));
     }
 
-    expect(warnSpy).toHaveBeenCalledTimes(2);
-    warnSpy.mockRestore();
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Subscriber limit (1000) reached for key "x"')
+    );
+    errorSpy.mockRestore();
 
-    // Cleanup
+    // Cleanup — including the no-op unsubscribes from capped calls
     unsubs.forEach(u => u());
+  });
+
+  it('applies the same subscriber cap to effect subscriptions', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const store = state({ x: 0 });
+
+    // Fill the key to the cap with plain subscribers…
+    const unsubs = [];
+    for (let i = 0; i < 1000; i++) {
+      unsubs.push(store.$subscribe('x', () => {}));
+    }
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    // …then an effect tracking the same key must hit the same cap
+    // (previously effects bypassed it entirely — inconsistent).
+    let runs = 0;
+    const cleanup = effect(() => {
+      void store.x;
+      runs++;
+    });
+
+    expect(runs).toBe(1); // initial run still happens
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Effect subscription ignored')
+    );
+
+    // The capped effect must not re-run (its subscription was rejected)
+    store.x = 1;
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(runs).toBe(1);
+
+    cleanup(); // covers the no-op unsubscribe path for effects
+    unsubs.forEach(u => u());
+    errorSpy.mockRestore();
   });
 
   it('reactive brand symbol is present but not enumerable', () => {


### PR DESCRIPTION
## Summary

This PR makes the state subscriber cap consistent across both `$subscribe` and effect subscriptions. When a key already has 1000 listeners, new effect registrations now log an error and become no-ops instead of silently bypassing the cap, and the behavior is covered by regression tests.

## Type of change

- [ ] `feat` — new feature or API addition
- [x] `fix` — bug fix
- [ ] `perf` — performance improvement (no API change)
- [ ] `refactor` — code restructuring (no behavior change)
- [ ] `docs` — documentation only
- [x] `test` — test addition or fix
- [ ] `chore` / `ci` / `build` — tooling, CI, build changes

## Changes

- `state.js` - applied the shared per-key subscriber cap to effect subscriptions and made capped registrations log an error and return a no-op unsubscribe.
- `state.test.js` - added regression tests covering the shared cap for `$subscribe` and effect subscriptions.
- `CHANGELOG.md` - documented the subscriber-cap consistency fix.

## Test plan

- [x] Added tests covering the new behavior
- [x] Ran `npm run coverage` — 100% coverage maintained
- [x] Ran `npm run typecheck`
- [x] Ran `npm run lint`
- [x] Ran `node scripts/complexity.js`
- [x] Ran `npm run size`

## Bundle size impact

No bundle impact

## Breaking changes

None

---

## Pre-merge checklist

- [x] `npm run coverage` passes — 100% statements, branches, functions, lines
- [x] `npm run typecheck` passes — zero TypeScript errors
- [x] `npm run lint` passes — cognitive complexity ≤ 15 per function
- [x] `node scripts/complexity.js` passes — max CC ≤ 10, MI ≥ 50
- [x] `npm run size` within budget — core ≤ 3 KB, addons ≤ 6 KB, handlers ≤ 2 KB
- [x] Commit messages follow Conventional Commits (`type(scope): subject`)
- [x] Docs updated if API changed (api, README.md, CONTRIBUTING.md) — not required; no API change
- [x] index.d.ts updated if public API changed — not required; no public API change