### PR TITLE
fix(core): make the reactive brand a real, shared symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ### Fixed
 
+- **`state()` / `isReactive()` — reactive brand was dead code:** every store
+  was stamped with a freshly created `Symbol('lume.reactive')` that nothing
+  could ever look up. The brand is now a shared registry symbol
+  (`Symbol.for('lume.reactive')`), stamped non-enumerably (spread copies are
+  not branded), and `isReactive()` checks it first — via the `in` operator, so
+  the check never registers an effect dependency. Duck-typing remains as a
+  fallback for stores from older versions.
 - **`state()` — subscriber cap consistency:** the per-key 1000-listener cap
   (added in 2.2.1) only applied to `$subscribe`; effect subscriptions bypassed
   it entirely. Both paths now share one capped registration helper, and

--- a/docs/api/core/isReactive.md
+++ b/docs/api/core/isReactive.md
@@ -16,7 +16,7 @@ function isReactive(value: any): boolean;
 
 ## Returns
 
-`true` if the value has a `$subscribe` method (duck-typing), `false` otherwise.
+`true` if the value carries the Lume reactive brand (a registry symbol stamped by `state()`), or — as a compatibility fallback — has a `$subscribe` method. `false` otherwise.
 
 ## Example
 
@@ -34,4 +34,4 @@ This is useful when writing utilities or addons that need to accept either a raw
 
 ## Note
 
-Detection uses duck-typing (`typeof obj.$subscribe === 'function'`). Any object with a `$subscribe` method will pass this check.
+Detection checks the shared brand symbol first (`Symbol.for('lume.reactive')`, checked with the `in` operator so it never registers an effect dependency), then falls back to duck-typing (`typeof obj.$subscribe === 'function'`) for stores created by older lume-js versions. The brand is a type tag, not a security boundary — any code can stamp it.

--- a/src/addons/index.d.ts
+++ b/src/addons/index.d.ts
@@ -396,7 +396,8 @@ export const debug: Debug;
 
 /**
  * Returns true if the value is a Lume reactive proxy created by state().
- * Uses duck-typing: checks for the presence of $subscribe.
+ * Checks the shared reactive brand symbol first (Symbol.for('lume.reactive')),
+ * then falls back to duck-typing ($subscribe) for older stores.
  * This is a type guard that narrows the type to ReactiveState.
  * 
  * @param obj - Value to check

--- a/src/addons/index.js
+++ b/src/addons/index.js
@@ -1,3 +1,5 @@
+import { REACTIVE_BRAND } from "../core/state.js";
+
 export { computed } from "./computed.js";
 export { watch } from "./watch.js";
 export { repeat, defaultFocusPreservation, defaultScrollPreservation } from "./repeat.js";
@@ -8,10 +10,18 @@ export { hydrateState } from "./hydrateState.js";
 
 /**
  * Returns true if the value is a Lume reactive proxy created by state().
- * Uses duck-typing: checks for the presence of $subscribe.
+ *
+ * Checks the shared reactive brand first (a registry symbol stamped by
+ * state(), reliable across module copies), then falls back to duck-typing
+ * ($subscribe) for proxies from older lume-js versions whose brand was not
+ * shared. The brand check uses the `in` operator, which does not pass
+ * through the proxy `get` trap — calling isReactive inside an effect does
+ * not create a spurious dependency.
+ *
  * @param {any} obj
  * @returns {boolean}
  */
 export function isReactive(obj) {
-  return !!(obj && typeof obj === 'object' && typeof obj.$subscribe === 'function');
+  return !!(obj && typeof obj === 'object' &&
+    (REACTIVE_BRAND in obj || typeof obj.$subscribe === 'function'));
 }

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -49,6 +49,19 @@ import { logError, logWarn } from '../utils/log.js';
 const readers = new Set();
 
 /**
+ * Brand symbol stamped on every object passed to state().
+ *
+ * Uses the global symbol registry (Symbol.for) so independent copies of
+ * lume-js on the same page (e.g. a CDN build next to a bundled chunk)
+ * agree on the same brand. This is a type tag for reliable detection
+ * (see isReactive in addons), not a security boundary — any code can
+ * stamp it.
+ *
+ * Internal API — exported for addons; not re-exported from the package root.
+ */
+export const REACTIVE_BRAND = Symbol.for('lume.reactive');
+
+/**
  * Run a function with a read observer active.
  * The observer receives (proxy, key, registerEffect) for every property read.
  * Multiple observers can be active simultaneously (nested effects, devtools, etc.)
@@ -172,9 +185,9 @@ export function state(obj) {
     });
   }
 
-  // Brand symbol for type-level reactive identification
-  const REACTIVE_BRAND = Symbol('lume.reactive');
-  obj[REACTIVE_BRAND] = true;
+  // Stamp the shared brand (non-enumerable: spreads/Object.assign copies
+  // of a store do not inherit the brand and won't masquerade as reactive).
+  Object.defineProperty(obj, REACTIVE_BRAND, { value: true });
 
   const MAX_SUBSCRIBERS = 1000;
   const noopUnsubscribe = () => {};

--- a/tests/addons/index.test.js
+++ b/tests/addons/index.test.js
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as addons from 'src/addons/index.js';
+import { state, effect } from 'src/index.js';
 
 describe('addons public API', () => {
   it('exposes computed and watch', () => {
@@ -43,5 +44,41 @@ describe('addons public API', () => {
   it('exposes hydrateState', () => {
     expect(addons).toHaveProperty('hydrateState');
     expect(typeof addons.hydrateState).toBe('function');
+  });
+});
+
+describe('isReactive', () => {
+  it('detects stores via the shared brand', () => {
+    const store = state({ count: 0 });
+    expect(addons.isReactive(store)).toBe(true);
+  });
+
+  it('rejects non-reactive values', () => {
+    expect(addons.isReactive({})).toBe(false);
+    expect(addons.isReactive(null)).toBe(false);
+    expect(addons.isReactive(undefined)).toBe(false);
+    expect(addons.isReactive(42)).toBe(false);
+    expect(addons.isReactive('store')).toBe(false);
+  });
+
+  it('falls back to duck-typing for unbranded store-likes (older versions)', () => {
+    const storeLike = { $subscribe: () => () => {} };
+    expect(addons.isReactive(storeLike)).toBe(true);
+  });
+
+  it('does not create a dependency when called inside an effect', async () => {
+    const store = state({ count: 0 });
+    const fn = vi.fn();
+
+    effect(() => {
+      fn();
+      addons.isReactive(store); // brand check must not track anything
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    store.count = 1; // not read by the effect → must not re-run
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/core/state.test.js
+++ b/tests/core/state.test.js
@@ -341,6 +341,26 @@ describe('state', () => {
     expect(brands.some(s => String(s) === 'Symbol(lume.reactive)')).toBe(true);
     expect(Object.keys(store)).not.toContain('Symbol(lume.reactive)');
   });
+
+  it('all stores share one registry brand symbol', () => {
+    const brand = Symbol.for('lume.reactive');
+    const storeA = state({ a: 1 });
+    const storeB = state({ b: 2 });
+
+    // Same shared symbol on every store — readable by anyone via Symbol.for
+    expect(brand in storeA).toBe(true);
+    expect(brand in storeB).toBe(true);
+
+    // Non-enumerable: a spread copy of a store does not inherit the brand
+    expect(brand in { ...storeA }).toBe(false);
+  });
+
+  it('re-wrapping the same object does not throw on the brand stamp', () => {
+    const obj = { x: 1 };
+    state(obj);
+    // Second wrap re-defines the brand with identical attributes — allowed
+    expect(() => state(obj)).not.toThrow();
+  });
 });
 
 describe('state edge cases', () => {


### PR DESCRIPTION
## Summary

This PR makes the reactive brand a real shared marker for Lume stores and hardens `isReactive()` so it detects reactive proxies reliably without creating phantom dependencies.

## Type of change

- [ ] `feat` — new feature or API addition
- [x] `fix` — bug fix
- [ ] `perf` — performance improvement (no API change)
- [ ] `refactor` — code restructuring (no behavior change)
- [ ] `docs` — documentation only
- [x] `test` — test addition or fix
- [ ] `chore` / `ci` / `build` — tooling, CI, build changes

## Changes

- `src/core/state.js` - made the reactive brand a shared `Symbol.for` marker and stamped it non-enumerably so spread copies are not misidentified as reactive.
- `src/addons/index.js` - updated `isReactive()` to check the shared brand first, with a fallback for older stores from earlier versions.
- `src/addons/index.d.ts` - adjusted typings to reflect the updated `isReactive()` behavior.
- `tests/core/state.test.js` and `tests/addons/index.test.js` - added regression coverage for shared-brand behavior, spread-copy handling, re-wrap safety, and `isReactive()` semantics.
- `docs/api/core/isReactive.md` and `CHANGELOG.md` - documented the fix and recorded it in the changelog.

## Test plan

- [x] Added tests covering the new behavior
- [x] Ran `npm run coverage` — 100% coverage maintained
- [x] Ran `npm run test -- tests/core/effect.test.js tests/core/state.test.js tests/addons/index.test.js` — 71 regression tests passed
- [x] Ran `npm run typecheck`, `npm run lint`, `node scripts/complexity.js`, and `npm run size` — all passed
- [x] Manual verification: no manual browser steps were required; validation was completed through the regression suite and the repository’s standard validation commands.

## Bundle size impact

No bundle impact.

## Breaking changes

None.

---

## Pre-merge checklist

- [x] `npm run coverage` passes — 100% statements, branches, functions, lines
- [x] `npm run typecheck` passes — zero TypeScript errors
- [x] `npm run lint` passes — cognitive complexity ≤ 15 per function
- [x] `node scripts/complexity.js` passes — max CC ≤ 10, MI ≥ 50
- [x] `npm run size` within budget — core ≤ 3 KB, addons ≤ 6 KB, handlers ≤ 2 KB
- [x] Commit messages follow Conventional Commits (`type(scope): subject`)
- [x] Docs updated if API changed (`docs/api/`, `README.md`, `CONTRIBUTING.md`)
- [x] `src/index.d.ts` updated if public API changed