### PR TITLE
fix(addons): persist storage default - no globalThis, survive Securit…

### DIFF
--- a/src/addons/persist.js
+++ b/src/addons/persist.js
@@ -54,6 +54,19 @@ function serializeKeys(store, watched) {
 }
 
 /**
+ * Default storage resolution. Wrapped because accessing localStorage can
+ * THROW (SecurityError) in cookie-blocked iframes and some privacy modes —
+ * persist() must degrade to a warning, never crash the app at setup.
+ */
+function defaultStorage() {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Sync store keys with a Storage object.
  *
  * @param {object} store - Reactive store created with state()
@@ -75,7 +88,7 @@ export function persist(store, storageKey, options = {}) {
 
   const storage = options.storage !== undefined
     ? options.storage
-    : globalThis.localStorage;
+    : defaultStorage();
 
   if (!storage || typeof storage.getItem !== 'function') {
     logWarn('[Lume.js] persist(): no storage available — persistence disabled');

--- a/tests/addons/persist.test.js
+++ b/tests/addons/persist.test.js
@@ -139,6 +139,48 @@ describe('persist', () => {
     warnSpy.mockRestore();
   });
 
+  it('disables itself when localStorage does not exist at all (Node-like)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const original = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    Object.defineProperty(window, 'localStorage', { configurable: true, value: undefined });
+
+    try {
+      const store = state({ count: 0 });
+      const stop = persist(store, 'app');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('no storage available')
+      );
+      stop();
+    } finally {
+      Object.defineProperty(window, 'localStorage', original);
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('survives environments where touching localStorage throws (blocked iframes)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Simulate Chrome's SecurityError on localStorage access when
+    // third-party cookies/storage are blocked.
+    const original = Object.getOwnPropertyDescriptor(window, 'localStorage');
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get() { throw new Error('SecurityError: access denied'); },
+    });
+
+    try {
+      const store = state({ count: 0 });
+      let stop;
+      expect(() => { stop = persist(store, 'app'); }).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('no storage available')
+      );
+      stop();
+    } finally {
+      Object.defineProperty(window, 'localStorage', original);
+      warnSpy.mockRestore();
+    }
+  });
+
   it('starts fresh on corrupted JSON with a warning', async () => {
     localStorage.setItem('app', '{not valid json');
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
## Summary

This PR hardens the persist addon by resolving storage through a guarded fallback instead of touching `globalThis.localStorage` directly. It now degrades gracefully in environments where storage is unavailable or access throws, such as blocked iframes or privacy-restricted contexts, while preserving the existing warning path and adding regression coverage for those cases.

## Type of change

- [x] `feat` — new feature or API addition
- [x] `fix` — bug fix
- [ ] `perf` — performance improvement (no API change)
- [ ] `refactor` — code restructuring (no behavior change)
- [ ] docs — documentation only
- [x] `test` — test addition or fix
- [ ] `chore` / `ci` / `build` — tooling, CI, build changes

## Changes

- persist.js - guard storage resolution so `persist()` no longer throws when `localStorage` is missing or access raises an error.
- persist.test.js - add regression tests for missing storage and blocked-iframe-style `SecurityError` access.

## Test plan

- [x] Added tests covering the new behavior
- [x] Ran `npx vitest run tests/addons/persist.test.js` — 17/17 tests passed
- [x] Manual verification: exercised the persist addon in jsdom with `localStorage` absent and with access throwing, confirming it warns and disables persistence without crashing
- [x] Attempted `npm run validate`; build, size, and complexity checks completed successfully, but ESLint stopped on an existing cognitive-complexity issue in repeat.js

## Bundle size impact

No bundle impact

## Breaking changes

None

---

## Pre-merge checklist

- [ ] `npm run coverage` passes — 100% statements, branches, functions, lines
- [ ] `npm run typecheck` passes — zero TypeScript errors
- [ ] `npm run lint` passes — cognitive complexity ≤ 15 per function
- [x] `node scripts/complexity.js` passes — max CC ≤ 10, MI ≥ 50
- [x] `npm run size` within budget — core ≤ 3 KB, addons ≤ 6 KB, handlers ≤ 2 KB
- [x] Commit messages follow Conventional Commits (`type(scope): subject`)
- [x] Docs updated if API changed (api, README.md, CONTRIBUTING.md)
- [x] index.d.ts updated if public API changed