### PR TITLE
docs: post-release cleanup - FAQ reality, design-decisions pruning, VDOM tradeoff

### DIFF
--- a/docs/design/design-decisions.md
+++ b/docs/design/design-decisions.md
@@ -913,24 +913,10 @@ bindDom(root, store, {
 
 ---
 
-## Hardening Updates (v2.3)
-
-Small behavior changes ratified alongside the features above:
-
-- **Subscriber cap applies to effects too, and fails loudly.** The per-key 1000-listener cap (v2.2.1) only guarded `$subscribe`; effect subscriptions bypassed it. Both paths now share one registration helper, and hitting the cap logs a `console.error` stating the listener will NOT receive updates — a protection that silently breaks the 1001st legitimate listener is indistinguishable from an app bug.
-- **The reactive brand is a real, shared symbol.** `Symbol.for('lume.reactive')` at module level (previously a unique symbol per store that nothing could read), stamped non-enumerably so `{ ...store }` copies are not branded. `isReactive()` checks the brand first via the `in` operator (no proxy `get` trap — calling it inside an effect creates no dependency), with `$subscribe` duck-typing kept as a fallback for older stores. The brand is a type tag, not a security boundary.
-
-### Amendment (2026-07-08, v2.3.1): `stringAttr` scheme guard matches the URL parser
-
-The v2.2.1 dangerous-scheme guard in `stringAttr()` compared the raw string against `/^(javascript|vbscript|data\s*:\s*text\/html)/i`. Two defects: it did not require the scheme colon (blocking legitimate relative URLs such as `javascript-tutorial.html`), and it missed values the browser URL parser still executes — parsers strip C0 controls, space, and tab/newline before reading the scheme, so `"\tjavascript:alert(1)"` and `"java\nscript:alert(1)"` sailed through. The guard now normalizes the value the way the parser does (strip `[\u0000-\u0020\u007F]`, lowercase) and requires the colon (`javascript:` / `vbscript:` / `data:text/html`). Checked only for URI attributes (`href`, `src`, `action`, `srcset`, `poster`, `formaction`), unchanged for all others.
-
----
-
 ## Future Considerations
 
 **Features We Might Add Later:**
 
-**After v1.0 stable:**
 - Array-based checkbox bindings (if clean solution found)
 - `contenteditable` support with cursor position handling
 - Debounced input binding option
@@ -962,50 +948,6 @@ If you think a decision should be reconsidered:
 3. **Propose implementation** (code or pseudocode)
 
 We're open to change, but will prioritize **simplicity and standards** over features!
-
----
-
-## Document History
-
-- **2026-07-08:**
-  - Amended the v2.3 hardening notes with the `stringAttr` scheme-guard fix
-    (URL-parser-equivalent normalization; colon required)
-
-- **2026-06-11:**
-  - Added `batch()` kernel decision (incl. the documented path to making it optional later, additive-only)
-  - Added explicit-deps coalescing, template-mode `repeat()`, `persist()`, and `lume-js/state` packaging decisions
-  - Amended the event-handling decision with the `data-on*` ruling; refined the "Will NOT add" wording
-  - Added v2.3 hardening notes (subscriber-cap parity, shared reactive brand)
-  - Fixed stale `repeat` status (was "@experimental v0.5.0")
-  - Test coverage now 425 tests / 100%
-
-- **2026-02-28:**
-  - Updated reactive data-* attributes section: now reflects handler system architecture
-  - Documented handler contract, composability, and tree-shaking
-  - Updated resolved/deferred lists (show, classToggle, stringAttr now implemented)
-  - Added handler system design decision rationale
-  - Updated test coverage to 231 tests
-- **2026-01-23:**
-  - Added reactive data-* attributes design decision
-  - Documented DOM properties vs setAttribute for boolean attrs
-  - Added ARIA handling rationale
-  - Updated supported/deferred attribute lists
-- **2026-01-14:**
-  - Added explicit effect dependencies decision (auto-tracking vs explicit tradeoff)
-  - Added debug addon design decision (why in addons, why stats tracking)
-- **2026-01-12:**
-  - Added `create`/`update` API design rationale
-  - Added reference + index optimization reasoning
-  - Updated test coverage to 162 tests
-- **2025-12-19:**
-  - Added plugin system rationale (v2.0)
-  - Updated test coverage to 148 tests
-- **2025-11-28:** 
-  - Added `repeat` addon decision and immutable array update reasoning
-  - Updated examples count and test coverage stats (114 tests)
-- **2025-11-20:** 
-  - Initial version documenting core decisions
-  - Added reactive identity (`isReactive`) decision and `$` meta method tracking exclusion
 
 ---
 

--- a/docs/design/design-decisions.md
+++ b/docs/design/design-decisions.md
@@ -624,7 +624,7 @@ store.$subscribe('text', (value) => {
 - ❌ Virtual DOM → Adds complexity, size, and abstractions
 - ❌ Template compilation → Requires build step
 
-**Tradeoff:** Large lists (1000+ items) may be slower than virtual DOM frameworks. For those cases, use pagination or virtualization libraries.
+**Tradeoff:** Reorder-heavy updates on very large lists (1000+ rows) may move more DOM nodes than minimal-move virtual DOM diffing — `repeat()` reconciles in a single forward pass, not with an LIS-style algorithm. For ordinary updates this is not a penalty: keyed element reuse plus the same-reference/same-index skip make the work proportional to what actually changed, with no vnode allocation at all. For very large lists, prefer pagination or virtualization — as you would with any framework.
 
 ---
 

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -2,7 +2,7 @@
 
 ## Is Lume.js production-ready?
 
-Lume 2.x is currently in beta. The core API (`state`, `bindDom`, `effect`) and all addons (`watch`, `computed`, `repeat`) are stable. The 1.x series is also stable and used in production.
+Yes. Lume 2.x is stable — the current release on npm is v2.3.1 (`npm install lume-js`), backed by 439 tests at 100% coverage and CI-enforced size budgets. The core API (`state`, `bindDom`, `effect`, `batch`) and all addons (`watch`, `computed`, `repeat`, `persist`, `withPlugins`, …) are stable. The 1.x series is legacy — see [Migrating from 1.x](migration.md).
 
 ## Does Lume work without a build step?
 
@@ -31,7 +31,7 @@ bindDom(document.getElementById('nav'), store);
 
 ## How does Lume compare to Alpine.js?
 
-Both work inline with server-rendered HTML. Lume uses standard `data-*` attributes; Alpine uses `x-*` directives with a custom expression syntax. Lume is smaller (~2.44 KB vs ~15 KB gzipped) and has no custom expression evaluator — logic lives in plain JS, not attribute strings.
+Both work inline with server-rendered HTML. Lume uses standard `data-*` attributes; Alpine uses `x-*` directives with a custom expression syntax. Lume is smaller (2.66 KB vs ~15 KB gzipped — 1.46 KB for the DOM-free kernel) and has no custom expression evaluator — logic lives in plain JS, not attribute strings.
 
 ## How does Lume compare to Vue 3's reactivity?
 
@@ -70,7 +70,7 @@ bindDom(document.body, store, { handlers: [show] });
 <div data-hidden="isLoggedIn">Please log in.</div>
 ```
 
-For replacing entire sections, assign `innerHTML` inside an `effect`:
+For replacing entire sections, assign `innerHTML` inside an `effect` — but only with markup you wrote yourself, never with user-supplied data (Lume's own bindings use `textContent` exactly to avoid HTML injection):
 
 ```js
 effect(() => {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6611,7 +6611,7 @@ store.$subscribe('text', (value) => {
 - ❌ Virtual DOM → Adds complexity, size, and abstractions
 - ❌ Template compilation → Requires build step
 
-**Tradeoff:** Large lists (1000+ items) may be slower than virtual DOM frameworks. For those cases, use pagination or virtualization libraries.
+**Tradeoff:** Reorder-heavy updates on very large lists (1000+ rows) may move more DOM nodes than minimal-move virtual DOM diffing — `repeat()` reconciles in a single forward pass, not with an LIS-style algorithm. For ordinary updates this is not a penalty: keyed element reuse plus the same-reference/same-index skip make the work proportional to what actually changed, with no vnode allocation at all. For very large lists, prefer pagination or virtualization — as you would with any framework.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2278,7 +2278,7 @@ FILE: docs/guides/faq.md
 
 ## Is Lume.js production-ready?
 
-Lume 2.x is currently in beta. The core API (`state`, `bindDom`, `effect`) and all addons (`watch`, `computed`, `repeat`) are stable. The 1.x series is also stable and used in production.
+Yes. Lume 2.x is stable — the current release on npm is v2.3.1 (`npm install lume-js`), backed by 439 tests at 100% coverage and CI-enforced size budgets. The core API (`state`, `bindDom`, `effect`, `batch`) and all addons (`watch`, `computed`, `repeat`, `persist`, `withPlugins`, …) are stable. The 1.x series is legacy — see [Migrating from 1.x](migration.md).
 
 ## Does Lume work without a build step?
 
@@ -2307,7 +2307,7 @@ bindDom(document.getElementById('nav'), store);
 
 ## How does Lume compare to Alpine.js?
 
-Both work inline with server-rendered HTML. Lume uses standard `data-*` attributes; Alpine uses `x-*` directives with a custom expression syntax. Lume is smaller (~2.44 KB vs ~15 KB gzipped) and has no custom expression evaluator — logic lives in plain JS, not attribute strings.
+Both work inline with server-rendered HTML. Lume uses standard `data-*` attributes; Alpine uses `x-*` directives with a custom expression syntax. Lume is smaller (2.66 KB vs ~15 KB gzipped — 1.46 KB for the DOM-free kernel) and has no custom expression evaluator — logic lives in plain JS, not attribute strings.
 
 ## How does Lume compare to Vue 3's reactivity?
 
@@ -2346,7 +2346,7 @@ bindDom(document.body, store, { handlers: [show] });
 <div data-hidden="isLoggedIn">Please log in.</div>
 ```
 
-For replacing entire sections, assign `innerHTML` inside an `effect`:
+For replacing entire sections, assign `innerHTML` inside an `effect` — but only with markup you wrote yourself, never with user-supplied data (Lume's own bindings use `textContent` exactly to avoid HTML injection):
 
 ```js
 effect(() => {
@@ -6900,24 +6900,10 @@ bindDom(root, store, {
 
 ---
 
-## Hardening Updates (v2.3)
-
-Small behavior changes ratified alongside the features above:
-
-- **Subscriber cap applies to effects too, and fails loudly.** The per-key 1000-listener cap (v2.2.1) only guarded `$subscribe`; effect subscriptions bypassed it. Both paths now share one registration helper, and hitting the cap logs a `console.error` stating the listener will NOT receive updates — a protection that silently breaks the 1001st legitimate listener is indistinguishable from an app bug.
-- **The reactive brand is a real, shared symbol.** `Symbol.for('lume.reactive')` at module level (previously a unique symbol per store that nothing could read), stamped non-enumerably so `{ ...store }` copies are not branded. `isReactive()` checks the brand first via the `in` operator (no proxy `get` trap — calling it inside an effect creates no dependency), with `$subscribe` duck-typing kept as a fallback for older stores. The brand is a type tag, not a security boundary.
-
-### Amendment (2026-07-08, v2.3.1): `stringAttr` scheme guard matches the URL parser
-
-The v2.2.1 dangerous-scheme guard in `stringAttr()` compared the raw string against `/^(javascript|vbscript|data\s*:\s*text\/html)/i`. Two defects: it did not require the scheme colon (blocking legitimate relative URLs such as `javascript-tutorial.html`), and it missed values the browser URL parser still executes — parsers strip C0 controls, space, and tab/newline before reading the scheme, so `"\tjavascript:alert(1)"` and `"java\nscript:alert(1)"` sailed through. The guard now normalizes the value the way the parser does (strip `[\u0000-\u0020\u007F]`, lowercase) and requires the colon (`javascript:` / `vbscript:` / `data:text/html`). Checked only for URI attributes (`href`, `src`, `action`, `srcset`, `poster`, `formaction`), unchanged for all others.
-
----
-
 ## Future Considerations
 
 **Features We Might Add Later:**
 
-**After v1.0 stable:**
 - Array-based checkbox bindings (if clean solution found)
 - `contenteditable` support with cursor position handling
 - Debounced input binding option
@@ -6949,50 +6935,6 @@ If you think a decision should be reconsidered:
 3. **Propose implementation** (code or pseudocode)
 
 We're open to change, but will prioritize **simplicity and standards** over features!
-
----
-
-## Document History
-
-- **2026-07-08:**
-  - Amended the v2.3 hardening notes with the `stringAttr` scheme-guard fix
-    (URL-parser-equivalent normalization; colon required)
-
-- **2026-06-11:**
-  - Added `batch()` kernel decision (incl. the documented path to making it optional later, additive-only)
-  - Added explicit-deps coalescing, template-mode `repeat()`, `persist()`, and `lume-js/state` packaging decisions
-  - Amended the event-handling decision with the `data-on*` ruling; refined the "Will NOT add" wording
-  - Added v2.3 hardening notes (subscriber-cap parity, shared reactive brand)
-  - Fixed stale `repeat` status (was "@experimental v0.5.0")
-  - Test coverage now 425 tests / 100%
-
-- **2026-02-28:**
-  - Updated reactive data-* attributes section: now reflects handler system architecture
-  - Documented handler contract, composability, and tree-shaking
-  - Updated resolved/deferred lists (show, classToggle, stringAttr now implemented)
-  - Added handler system design decision rationale
-  - Updated test coverage to 231 tests
-- **2026-01-23:**
-  - Added reactive data-* attributes design decision
-  - Documented DOM properties vs setAttribute for boolean attrs
-  - Added ARIA handling rationale
-  - Updated supported/deferred attribute lists
-- **2026-01-14:**
-  - Added explicit effect dependencies decision (auto-tracking vs explicit tradeoff)
-  - Added debug addon design decision (why in addons, why stats tracking)
-- **2026-01-12:**
-  - Added `create`/`update` API design rationale
-  - Added reference + index optimization reasoning
-  - Updated test coverage to 162 tests
-- **2025-12-19:**
-  - Added plugin system rationale (v2.0)
-  - Updated test coverage to 148 tests
-- **2025-11-28:** 
-  - Added `repeat` addon decision and immutable array update reasoning
-  - Updated examples count and test coverage stats (114 tests)
-- **2025-11-20:** 
-  - Initial version documenting core decisions
-  - Added reactive identity (`isReactive`) decision and `$` meta method tracking exclusion
 
 ---
 


### PR DESCRIPTION
## Summary

Post-release documentation cleanup. Fixes the FAQ's badly stale "Lume 2.x is currently in beta" claim (2.3.1 is stable on npm `latest`), prunes the design-decisions page down to the ratified decisions themselves (the "Hardening Updates (v2.3)" and "Document History" sections are removed — their content remains recorded in CHANGELOG.md and git history), and rewrites the "Why No Virtual DOM?" tradeoff to reflect what `repeat()` actually does since keyed reconciliation landed.

## Type of change

- [ ] `feat` — new feature or API addition
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no API change)
- [ ] `refactor` — code restructuring (no behavior change)
- [x] `docs` — documentation only
- [ ] `test` — test addition or fix
- [ ] `chore` / `ci` / `build` — tooling, CI, build changes

## Changes

- `docs/guides/faq.md` — production-ready answer now states v2.3.1 stable with 439 tests/100% coverage; Alpine size comparison corrected (2.66 KB / 1.46 KB kernel, was a stale ~2.44 KB); addon/core API lists gain `batch`, `persist`, `withPlugins`; the `innerHTML` conditional-rendering answer carries a trusted-markup-only caution
- `docs/design/design-decisions.md` — "Hardening Updates (v2.3)" and "Document History" sections removed per maintainer decision; stale "After v1.0 stable:" label dropped from Future Considerations; "Why No Virtual DOM?" tradeoff updated: keyed reuse + same-reference/same-index skip make ordinary updates proportional to the change, and the honest residual tradeoff (single forward-pass reconcile, no LIS-style minimal moves on large reorders) is stated as such
- `llms.txt` / `llms-full.txt` — regenerated from the updated docs

## Test plan

- [ ] Added tests covering the new behavior — n/a, docs only
- [x] Ran `npm run coverage` — 439 tests passing, 100% coverage (unaffected)
- [x] `node scripts/build-llms.js --check` — bundles in sync with the docs tree
- [x] Manual verification: reviewed rendered markdown for the three touched pages

## Bundle size impact

No bundle impact (docs only).

## Breaking changes

None.

---

## Pre-merge checklist

- [x] `npm run coverage` passes — 100% statements, branches, functions, lines
- [x] `npm run typecheck` passes — zero TypeScript errors
- [x] `npm run lint` passes — cognitive complexity ≤ 15 per function
- [x] `node scripts/complexity.js` passes — max CC ≤ 10, MI ≥ 50
- [x] `npm run size` within budget — core ≤ 3 KB, addons ≤ 6 KB, handlers ≤ 2 KB
- [x] Commit messages follow Conventional Commits (`type(scope): subject`)
- [x] Docs updated if API changed (`docs/api/`, `README.md`, `CONTRIBUTING.md`)
- [x] `src/index.d.ts` updated if public API changed — n/a
