### PR TITLE
feat(examples): rebuild batch demo as a continuous live stress test

### DIFF
--- a/examples/batch/index.html
+++ b/examples/batch/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Lume.js - batch() benchmark</title>
+  <title>Lume.js - batch() live stress test</title>
   <style>
     :root {
       --bg: #fff;
@@ -14,6 +14,7 @@
       --accent-hover: #1d4ed8;
       --ok: #16a34a;
       --warn: #d97706;
+      --bad: #dc2626;
     }
     * { box-sizing: border-box; }
     body {
@@ -26,7 +27,6 @@
       line-height: 1.45;
     }
     h1 { font-size: 22px; margin: 0 0 4px; }
-    h2 { font-size: 18px; margin: 0 0 10px; }
     .sub { color: var(--muted); margin: 0 0 12px; font-size: 14px; }
     .card {
       border: 1px solid var(--border);
@@ -36,43 +36,59 @@
       background: #fff;
     }
     button {
-      padding: 9px 14px;
+      padding: 9px 16px;
       border: 0;
       border-radius: 8px;
       background: var(--accent);
       color: #fff;
       font-weight: 600;
       cursor: pointer;
+      font-size: 15px;
     }
     button:hover { background: var(--accent-hover); }
-    button:disabled { opacity: 0.5; cursor: wait; }
     code { background: #f3f4f6; padding: 2px 6px; border-radius: 4px; font-size: 13px; }
+    pre { background: #f3f4f6; padding: 10px 12px; border-radius: 8px; overflow-x: auto; }
+    pre code { background: none; padding: 0; }
 
-    /* Controls + live frame-health meter, first thing on the page */
-    .controls-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-    .meter { display: flex; align-items: center; gap: 10px; margin-left: auto; }
-    .pulse {
-      width: 14px; height: 14px; border-radius: 50%;
-      background: var(--ok);
-      animation: pulse 1s ease-in-out infinite;
+    .controls-row { display: flex; align-items: center; gap: 18px; flex-wrap: wrap; }
+    .control { display: flex; align-items: center; gap: 8px; font-size: 14px; }
+    .control input[type="range"] { width: 160px; }
+    .toggle { font-weight: 600; user-select: none; cursor: pointer; }
+    .toggle input { transform: scale(1.3); margin-right: 6px; cursor: pointer; }
+
+    /* Readouts: FPS is THE number */
+    .readouts { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 14px; }
+    .readout {
+      flex: 1; min-width: 150px;
+      border: 1px solid var(--border); border-radius: 8px;
+      padding: 10px 14px; text-align: center;
     }
-    @keyframes pulse { 50% { transform: scale(1.8); opacity: 0.4; } }
+    .readout .v { font-size: 42px; font-weight: 700; line-height: 1.1; }
+    .readout .v.small { font-size: 28px; padding-top: 8px; }
+    .readout .l { color: var(--muted); font-size: 12px; margin-top: 2px; }
+    .fps-good { color: var(--ok); }
+    .fps-mid { color: var(--warn); }
+    .fps-bad { color: var(--bad); }
 
-    /* Results */
-    .results { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 12px; }
-    .result {
-      flex: 1; min-width: 280px;
-      border: 1px solid var(--border); border-radius: 8px; padding: 12px 14px;
+    /* Feel the main thread: JS-driven dot + an input to type into */
+    .feel { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; margin-top: 14px; }
+    .track {
+      position: relative; width: 120px; height: 20px;
+      border: 1px solid var(--border); border-radius: 10px;
     }
-    .result h3 { margin: 0 0 6px; font-size: 13px; color: var(--muted); }
-    .result .big { font-size: 26px; font-weight: 700; line-height: 1.2; }
-    .result .biglabel { color: var(--muted); font-size: 12px; margin-bottom: 4px; }
-    .result .ops { font-size: 16px; font-weight: 600; margin: 2px 0; }
-    .result .runs { color: var(--warn); font-weight: 600; }
-    .result.batch .runs { color: var(--ok); }
-    .ratio { color: var(--ok); font-weight: 700; margin-top: 4px; min-height: 1.4em; }
+    .track .dot {
+      position: absolute; top: 3px; left: 3px;
+      width: 12px; height: 12px; border-radius: 50%;
+      background: var(--accent);
+      will-change: transform;
+    }
+    .feel input[type="text"] {
+      flex: 1; min-width: 200px;
+      padding: 8px 10px; border: 1px solid var(--border); border-radius: 8px;
+      font-size: 14px;
+    }
+    .feel .hint { color: var(--muted); font-size: 12.5px; }
 
-    /* The dashboard being driven */
     .stats { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 10px; }
     .stat {
       flex: 1; min-width: 90px;
@@ -82,58 +98,40 @@
     .stat .v { font-size: 18px; font-weight: 700; }
     .stat .l { color: var(--muted); font-size: 11px; }
 
-    #grid {
-      display: grid;
-      grid-template-columns: repeat(50, 1fr);
-      gap: 2px;
-    }
+    #grid { display: grid; gap: 1px; }
     #grid .cell {
-      height: 12px;
-      border-radius: 2px;
-      background: hsl(var(--h, 120) 70% 55%);
-      transition: background 120ms linear;
+      aspect-ratio: 1;
+      min-height: 6px;
+      border-radius: 1px;
+      background: hsl(var(--h, 200) 75% 55%);
     }
     .footnote { color: var(--muted); font-size: 12.5px; }
+    details summary { cursor: pointer; font-weight: 600; }
   </style>
 </head>
 <body>
-  <h1>batch() — live benchmark</h1>
+  <h1>batch(): live stress test</h1>
   <p class="sub">
-    <strong>500 independent stores</strong> (one per cell below), each with its own fine-grained
-    effect, plus <strong>one aggregate effect</strong> that reads all 500. Each run fires
-    <strong>100 write-bursts</strong>; every burst mutates all 500 stores. Per-store batching runs
-    the aggregate once per store flush — <code>batch()</code> runs it <em>once per burst</em>.
-    Numbers are measured live on your machine, not quoted.
+    Every frame, this page writes a new value into <strong data-bind="storeLabel"></strong> independent stores, each driving its own cell below, plus one aggregate effect that reads all of them. Without <code>batch()</code> that aggregate re-runs once per store, every frame. Flip the toggle while it runs and watch the frame rate recover.
   </p>
 
   <div class="card">
     <div class="controls-row">
-      <button id="run-plain">Run WITHOUT batch</button>
-      <button id="run-batch">Run WITH batch()</button>
-      <span class="meter">
-        <span class="pulse"></span>
-        <span class="footnote">this pulse never stops · worst frame (last 1s): <strong data-bind="worstFrame"></strong></span>
-      </span>
+      <button id="start">Start</button>
+      <label class="toggle control"><input type="checkbox" id="use-batch" />use batch()</label>
+      <label class="control">stores <input type="range" id="stores" min="500" max="3000" step="500" value="1000" /> <strong data-bind="storeLabel"></strong></label>
     </div>
 
-    <div class="results">
-      <div class="result">
-        <h3>WITHOUT batch — per-store flushes</h3>
-        <div class="big" data-bind="plainTime"></div>
-        <div class="biglabel">main-thread work (wall clock: <span data-bind="plainWall"></span>)</div>
-        <div class="ops"><span data-bind="plainOps"></span> total operations</div>
-        <div>aggregate effect ran <span class="runs" data-bind="plainAgg"></span> times</div>
-        <div class="footnote">cell effects: <span data-bind="plainCell"></span> runs (same in both modes — granular updates are never sacrificed)</div>
-      </div>
-      <div class="result batch">
-        <h3>WITH batch() — one flush per burst</h3>
-        <div class="big" data-bind="batchTime"></div>
-        <div class="biglabel">main-thread work (wall clock: <span data-bind="batchWall"></span>)</div>
-        <div class="ops"><span data-bind="batchOps"></span> total operations</div>
-        <div>aggregate effect ran <span class="runs" data-bind="batchAgg"></span> times</div>
-        <div class="footnote">cell effects: <span data-bind="batchCell"></span> runs</div>
-        <div class="ratio" data-bind="ratio"></div>
-      </div>
+    <div class="readouts">
+      <div class="readout"><div class="v" id="fps" data-bind="fps"></div><div class="l">frames per second</div></div>
+      <div class="readout"><div class="v small" data-bind="worst"></div><div class="l">worst frame (last second)</div></div>
+      <div class="readout"><div class="v small" data-bind="aggPerFrame"></div><div class="l">aggregate runs per frame</div></div>
+    </div>
+
+    <div class="feel">
+      <span class="track"><span class="dot" id="dot"></span></span>
+      <input type="text" placeholder="Type here while it runs" />
+      <span class="hint">Both are driven by the main thread. When it stalls, they stall.</span>
     </div>
   </div>
 
@@ -148,29 +146,18 @@
   </div>
 
   <div class="card">
-    <h2>The point</h2>
-    <p>
-      Everything on this page — 500 stores, 501 effects, two-way DOM binding, the batcher —
-      is <strong>2.66&nbsp;KB gzipped</strong> of library, no build step, valid HTML.
-      In component frameworks, a multi-store burst like this re-renders every subscribed
-      component unless you hand-tune memoization and selectors; the framework runtime alone
-      ships 15–45&nbsp;KB before your first line. Here the entire optimization is one
-      explicit, standard-JavaScript function call:
-    </p>
-    <pre><code>batch(() => {
+    <details>
+      <summary>What batch() actually changes</summary>
+      <p>
+        Lume already batches per store: many writes to one store in a tick trigger one flush. But an effect that reads many stores still re-runs once per store that flushed. <code>batch(fn)</code> flushes every store touched inside <code>fn</code> together, so cross-store effects run exactly once:
+      </p>
+      <pre><code>batch(() => {
   for (const s of stores) s.value = next(s.value);
 });</code></pre>
-    <p class="footnote">
-      Fair-play notes: both modes await a timeout between bursts (an event-like cadence), so
-      scheduling overhead is identical — "main-thread work" excludes that shared wait time and
-      counts only the synchronous write + flush work of each burst. "Total operations" =
-      store writes + store reads performed by effects + effect executions, all counted (or
-      derived exactly) from live counters. The per-cell effects run the same number of times
-      in both modes; only the cross-store aggregate differs — that is exactly what
-      <code>batch()</code> deduplicates. Without batch, Lume's per-store microtask batching
-      is still doing its normal job — this page measures the one case it deliberately does
-      not cover, and what the opt-in escape hatch buys.
-    </p>
+      <p class="footnote">
+        The per-cell effects run the same number of times in both modes; batch() never makes granular updates coarser. Only the cross-store aggregate is deduplicated, and that is what "aggregate runs per frame" shows: store count without batch, 1 with it. Everything on this page (the stores, the effects, the DOM binding, the batcher) is 2.66 KB gzipped of library, no build step, valid HTML.
+      </p>
+    </details>
   </div>
 
   <script type="module" src="./main.js"></script>

--- a/examples/batch/main.js
+++ b/examples/batch/main.js
@@ -1,153 +1,140 @@
 import { state, effect, bindDom, batch } from 'lume-js';
 
-const STORES = 500;
-const BURSTS = 100;
-
-// 500 independent stores — one per dashboard cell, as separate widgets/modules would have
-const stores = Array.from({ length: STORES }, () => state({ value: 50 }));
-
 // UI store for the readouts (data-bind targets)
 const ui = state({
-  sum: 0, avg: '0.0', min: 0, max: 0,
-  worstFrame: '…',
-  plainTime: '—', plainWall: '—', plainAgg: '—', plainCell: '—', plainOps: '—',
-  batchTime: '—', batchWall: '—', batchAgg: '—', batchCell: '—', batchOps: '—',
-  ratio: '',
+  fps: '—',
+  worst: '—',
+  aggPerFrame: '—',
+  storeLabel: '',
+  sum: '—', avg: '—', min: '—', max: '—',
 });
 bindDom(document.body, ui);
 
-const fmt = n => n.toLocaleString('en-US');
-
-// ── Fine-grained layer: one effect per store, driving its own cell ────────
-// These run once per changed store in BOTH modes — batch() never makes
-// granular updates coarser.
 const grid = document.getElementById('grid');
-let cellRuns = 0;
-for (const s of stores) {
-  const cell = document.createElement('div');
-  cell.className = 'cell';
-  grid.appendChild(cell);
-  effect(() => {
-    const v = s.value;
-    cellRuns++;
-    cell.style.setProperty('--h', String(Math.round(v * 1.2 + 60)));
-  });
-}
+const fpsEl = document.getElementById('fps');
+const dot = document.getElementById('dot');
+const startBtn = document.getElementById('start');
+const batchToggle = document.getElementById('use-batch');
+const storesSlider = document.getElementById('stores');
 
-// ── Cross-store layer: ONE aggregate effect reading all 500 stores ────────
-// This is the dashboard summary — and the thing per-store batching runs
-// once per mutated store, but batch() runs once per burst.
+// ── Store setup (rebuilt when the slider moves) ────────────────────────────
+let stores = [];
+let disposers = [];
 let aggRuns = 0;
-effect(() => {
-  let sum = 0;
-  let min = Infinity;
-  let max = -Infinity;
-  for (let i = 0; i < STORES; i++) {
-    const v = stores[i].value;
-    sum += v;
-    if (v < min) min = v;
-    if (v > max) max = v;
+
+function setup(count) {
+  for (const dispose of disposers) dispose();
+  disposers = [];
+  grid.textContent = '';
+
+  // One independent store per cell, as separate widgets/modules would have.
+  stores = Array.from({ length: count }, () => state({ value: Math.random() * 100 }));
+  ui.storeLabel = count.toLocaleString('en-US');
+
+  // Keep the grid roughly 2:1 regardless of store count.
+  grid.style.gridTemplateColumns = `repeat(${Math.ceil(Math.sqrt(count * 2))}, 1fr)`;
+
+  // Fine-grained layer: one effect per store, driving its own cell's hue.
+  // These run once per changed store in BOTH modes; batch() never makes
+  // granular updates coarser.
+  for (const s of stores) {
+    const cell = document.createElement('div');
+    cell.className = 'cell';
+    grid.appendChild(cell);
+    disposers.push(effect(() => {
+      cell.style.setProperty('--h', String(Math.round(s.value * 3.3)));
+    }));
   }
-  aggRuns++;
-  ui.sum = Math.round(sum);
-  ui.avg = (sum / STORES).toFixed(1);
-  ui.min = Math.round(min);
-  ui.max = Math.round(max);
-});
 
-// ── The benchmark ──────────────────────────────────────────────────────────
-// One burst = a random-walk write to every store (think: a tick of live
-// market/sensor data hitting every widget at once).
-function burst() {
-  for (let i = 0; i < STORES; i++) {
-    const s = stores[i];
-    s.value = Math.max(0, Math.min(100, s.value + (Math.random() * 10 - 5)));
-  }
-}
-
-// Event-like cadence between bursts; identical in both modes so scheduling
-// overhead cancels out and only effect work differs.
-const nextTick = () => new Promise(resolve => setTimeout(resolve));
-
-const buttons = [...document.querySelectorAll('button')];
-let running = false;
-let plainOpsTotal = 0;
-let batchOpsTotal = 0;
-
-async function run(useBatch) {
-  if (running) return;
-  running = true;
-  buttons.forEach(b => { b.disabled = true; });
-
-  const agg0 = aggRuns;
-  const cell0 = cellRuns;
-  const wall0 = performance.now();
-  let work = 0;
-
-  for (let b = 0; b < BURSTS; b++) {
-    const t0 = performance.now();
-    if (useBatch) {
-      batch(burst);    // one synchronous flush: aggregate runs ONCE
-    } else {
-      burst();         // per-store flushes: aggregate runs once per store
+  // Cross-store layer: ONE aggregate effect reading every store. Per-store
+  // flushing runs this once per mutated store; batch() runs it once per frame.
+  disposers.push(effect(() => {
+    let sum = 0;
+    let min = Infinity;
+    let max = -Infinity;
+    for (let i = 0; i < stores.length; i++) {
+      const v = stores[i].value;
+      sum += v;
+      if (v < min) min = v;
+      if (v > max) max = v;
     }
-    // Without batch, each store flushes in its own microtask queued during
-    // burst(); awaiting a resolved promise queues this continuation AFTER
-    // those flushes, so `work` captures the effect work in both modes.
-    await Promise.resolve();
-    work += performance.now() - t0;
-    await nextTick();
-  }
-
-  const wall = performance.now() - wall0;
-  const aggDelta = aggRuns - agg0;
-  const cellDelta = cellRuns - cell0;
-  // writes + reads performed by effects (aggregate reads all stores per run,
-  // each cell effect reads its one store) + effect executions
-  const totalOps =
-    STORES * BURSTS +
-    aggDelta * STORES + cellDelta +
-    aggDelta + cellDelta;
-
-  if (useBatch) {
-    ui.batchTime = `${work.toFixed(0)} ms`;
-    ui.batchWall = `${wall.toFixed(0)} ms`;
-    ui.batchAgg = fmt(aggDelta);
-    ui.batchCell = fmt(cellDelta);
-    ui.batchOps = fmt(totalOps);
-    batchOpsTotal = totalOps;
-  } else {
-    ui.plainTime = `${work.toFixed(0)} ms`;
-    ui.plainWall = `${wall.toFixed(0)} ms`;
-    ui.plainAgg = fmt(aggDelta);
-    ui.plainCell = fmt(cellDelta);
-    ui.plainOps = fmt(totalOps);
-    plainOpsTotal = totalOps;
-  }
-  if (plainOpsTotal && batchOpsTotal) {
-    ui.ratio = `${Math.round(plainOpsTotal / batchOpsTotal)}× fewer operations with batch()`;
-  }
-
-  buttons.forEach(b => { b.disabled = false; });
-  running = false;
+    aggRuns++;
+    ui.sum = Math.round(sum).toLocaleString('en-US');
+    ui.avg = (sum / stores.length).toFixed(1);
+    ui.min = String(Math.round(min));
+    ui.max = String(Math.round(max));
+  }));
 }
 
-document.getElementById('run-plain').addEventListener('click', () => run(false));
-document.getElementById('run-batch').addEventListener('click', () => run(true));
+// ── The write burst: one new value per store, every frame ─────────────────
+function burst() {
+  for (let i = 0; i < stores.length; i++) {
+    const s = stores[i];
+    let v = s.value + (Math.random() * 24 - 12);
+    if (v < 0) v = -v;
+    if (v > 100) v = 200 - v;
+    s.value = v;
+  }
+}
 
-// ── Frame-health meter ─────────────────────────────────────────────────────
-// Worst frame-to-frame gap over the last second; a blocked main thread
-// shows up here (and in the CSS pulse stuttering) immediately.
+// ── Main loop + frame instrumentation ──────────────────────────────────────
+let running = false;
+
+let frames = 0;
+let worstGap = 0;
 let lastFrame = performance.now();
-let worst = 0;
+let lastSample = performance.now();
+let aggMark = 0;
+
 function onFrame(now) {
-  const delta = now - lastFrame;
+  const gap = now - lastFrame;
   lastFrame = now;
-  if (delta > worst) worst = delta;
+  if (gap > worstGap) worstGap = gap;
+  frames++;
+
+  // JS-driven dot: positioned from here, every frame. Unlike a CSS animation
+  // (which the compositor keeps running), this visibly freezes when the main
+  // thread stalls.
+  dot.style.transform = `translateX(${(Math.sin(now / 300) + 1) * 51}px)`;
+
+  if (running) {
+    if (batchToggle.checked) {
+      batch(burst); // all stores flush together: aggregate runs ONCE
+    } else {
+      burst(); // per-store flushes: aggregate runs once per store
+    }
+    // Without batch, the flushes are microtasks queued during burst(); they
+    // run after this callback but before the next frame, so the frame-gap
+    // meter above captures their full cost either way.
+  }
+
+  const elapsed = now - lastSample;
+  if (elapsed >= 1000) {
+    ui.fps = String(Math.round((frames * 1000) / elapsed));
+    ui.worst = `${worstGap.toFixed(0)} ms`;
+    ui.aggPerFrame = running
+      ? Math.round((aggRuns - aggMark) / frames).toLocaleString('en-US')
+      : '0';
+    const fps = (frames * 1000) / elapsed;
+    fpsEl.className = `v ${fps >= 50 ? 'fps-good' : fps >= 30 ? 'fps-mid' : 'fps-bad'}`;
+    frames = 0;
+    worstGap = 0;
+    aggMark = aggRuns;
+    lastSample = now;
+  }
+
   requestAnimationFrame(onFrame);
 }
+
+// ── Controls ───────────────────────────────────────────────────────────────
+startBtn.addEventListener('click', () => {
+  running = !running;
+  startBtn.textContent = running ? 'Stop' : 'Start';
+});
+
+storesSlider.addEventListener('change', () => {
+  setup(Number(storesSlider.value));
+});
+
+setup(Number(storesSlider.value));
 requestAnimationFrame(onFrame);
-setInterval(() => {
-  ui.worstFrame = `${worst.toFixed(0)} ms`;
-  worst = 0;
-}, 1000);

--- a/examples/index.html
+++ b/examples/index.html
@@ -120,8 +120,8 @@
         },
         {
           slug: 'batch',
-          title: 'batch() benchmark',
-          desc: 'Live measured benchmark: 500 stores, 100 write-bursts — aggregate effect runs 50,000× without batch, 100× with. Live operation counters and frame-health meter included.',
+          title: 'batch() live stress test',
+          desc: 'Thousands of stores written every frame. Toggle batch() while it runs and watch the FPS recover: the cross-store aggregate effect drops from once per store to once per frame.',
           badge: 'NEW'
         },
         {


### PR DESCRIPTION
## Summary

Rebuilds the batch() example from a button-triggered benchmark into a continuous live stress test. The old page could not show what it claimed: its frame-health pulse was a CSS transform animation that the compositor keeps running even while the main thread is blocked, the cell hues drifted a few degrees around green behind a 120ms transition so the grid looked static, and the results were six numbers plus three paragraphs of footnotes. The new page writes every store on every frame and lets you flip batch() on and off while it runs, so the FPS collapse and recovery is something you watch happen instead of read about.

## Type of change

- [x] `feat` — new feature or API addition (examples only, no library change)
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no API change)
- [ ] `refactor` — code restructuring (no behavior change)
- [ ] `docs` — documentation only
- [ ] `test` — test addition or fix
- [ ] `chore` / `ci` / `build` — tooling, CI, build changes

## Changes

- `examples/batch/main.js`: continuous rAF loop writes a new value into every store each frame; a live checkbox switches between plain writes (aggregate effect re-runs once per store per frame) and `batch()` (once per frame). Store count is adjustable (500 to 3,000) and rebuilds stores, cells, and effects via effect disposers.
- `examples/batch/main.js`: instrumentation is rAF-based: FPS (color-coded), worst frame gap over the last second, and aggregate runs per frame, which reads the store count without batch and 1 with it.
- `examples/batch/index.html`: the compositor-driven CSS pulse is replaced by a JS-driven dot plus a plain text input, both of which visibly stall when the main thread stalls. Cell hues span the full color wheel with no transition. Explanation is one sentence up top plus a collapsed details block.
- `examples/index.html`: demo card title and description updated to match.
- The slider caps at 3,000 stores because the un-batched cost grows quadratically; measured in Chrome at 1,000 stores a frame costs 155 ms of main-thread work without batch (1,000 aggregate runs) vs 0.5 ms with it (1 run). At 5,000 stores an un-batched frame takes multiple seconds and the page feels crashed rather than stressed.

## Test plan

- [ ] Added tests covering the new behavior (examples-only change; no library code touched)
- [x] Ran `npm run coverage` — 100% coverage maintained (457 tests pass)
- [x] Manual verification: jsdom smoke test drove synthetic frames through the page (setup, start/stop, batch toggle, slider rebuild, sampler readouts); loaded the page in Chrome via `npm run dev`, confirmed rendering and the start/toggle flow, and measured per-frame main-thread cost in both modes at 1,000 stores (155 ms vs 0.5 ms).

## Bundle size impact

No bundle impact. `npm run size` unchanged and within budget (examples are not built into dist).

## Breaking changes

None.

---

## Pre-merge checklist

- [x] `npm run coverage` passes — 100% statements, branches, functions, lines
- [x] `npm run typecheck` passes — zero TypeScript errors
- [x] `npm run lint` passes — cognitive complexity ≤ 15 per function
- [x] `node scripts/complexity.js` passes — max CC ≤ 10, MI ≥ 50
- [x] `npm run size` within budget — core ≤ 3 KB, addons ≤ 6 KB, handlers ≤ 2 KB
- [x] Commit messages follow Conventional Commits (`type(scope): subject`)
- [x] Docs updated if API changed (no API change; examples card text updated)
- [x] `src/index.d.ts` updated if public API changed (no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015aXvXikSuma6iQ9Esp9RYy