### PR TITLE
feat(examples): repeat() playground - drag-to-reorder grid with live DOM-move counts

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -125,6 +125,12 @@
           badge: 'NEW'
         },
         {
+          slug: 'repeat-playground',
+          title: 'repeat() playground',
+          desc: 'Thousands of colored tiles you reorder by hand — drag, shuffle, sort, storm. A live counter shows the DOM moves each update really cost: one drag is 1 move.',
+          badge: 'NEW'
+        },
+        {
           slug: 'template-list',
           title: 'Template Lists',
           desc: 'Keyed lists from a standard &lt;template&gt; element — data-bind per item, zero imperative DOM code.',
@@ -139,12 +145,6 @@
           slug: 'form-heavy',
           title: 'Form Heavy',
           desc: 'Multi-step wizard: validation, async checks, conditional fields.',
-          badge: 'ADVANCED'
-        },
-        {
-          slug: 'repeat-test',
-          title: 'Repeat Test',
-          desc: 'Testing the repeat addon with dynamic lists.',
           badge: 'ADVANCED'
         },
         {

--- a/examples/index.html
+++ b/examples/index.html
@@ -127,7 +127,7 @@
         {
           slug: 'template-list',
           title: 'Template Lists',
-          desc: 'Keyed lists from a standard <template> element — data-bind per item, zero imperative DOM code.',
+          desc: 'Keyed lists from a standard &lt;template&gt; element — data-bind per item, zero imperative DOM code.',
           badge: 'NEW'
         },
         {

--- a/examples/repeat-playground/index.html
+++ b/examples/repeat-playground/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Lume.js — repeat() playground</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect x='1' y='1' width='6' height='6' rx='1.5' fill='%23f87171'/><rect x='9' y='1' width='6' height='6' rx='1.5' fill='%23fbbf24'/><rect x='1' y='9' width='6' height='6' rx='1.5' fill='%2334d399'/><rect x='9' y='9' width='6' height='6' rx='1.5' fill='%236366f1'/></svg>" />
+  <style>
+    :root {
+      --bg: #0b0e14;
+      --panel: #121826;
+      --border: #1f2937;
+      --fg: #e5e7eb;
+      --muted: #7c8698;
+      --accent: #6366f1;
+      --ok: #34d399;
+      --warn: #fbbf24;
+      --bad: #f87171;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; }
+    body {
+      font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--fg);
+      max-width: 1080px;
+      margin: 0 auto;
+      padding: 20px 20px 40px;
+    }
+
+    header { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; margin-bottom: 14px; }
+    h1 { font-size: 20px; margin: 0; font-weight: 700; letter-spacing: -0.01em; }
+    h1 code { font-family: ui-monospace, 'SF Mono', Menlo, monospace; color: var(--accent); background: none; }
+    .hint { color: var(--muted); font-size: 14px; }
+
+    .bar {
+      display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px 12px;
+      margin-bottom: 10px;
+    }
+    button {
+      padding: 7px 14px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: #1a2234;
+      color: var(--fg);
+      font-weight: 600;
+      font-size: 13px;
+      cursor: pointer;
+      transition: background 120ms ease, border-color 120ms ease;
+    }
+    button:hover { background: #232e47; border-color: #2c3a57; }
+    button.storm-on { background: var(--bad); border-color: var(--bad); color: #14060a; }
+    .spacer { flex: 1; }
+    .count-control { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--muted); }
+    .count-control input { width: 130px; accent-color: var(--accent); }
+    .count-control output { color: var(--fg); font-variant-numeric: tabular-nums; min-width: 44px; text-align: right; }
+
+    .readouts { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 14px; }
+    .readout {
+      flex: 1; min-width: 110px;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px 14px;
+    }
+    .readout .v {
+      font-size: 24px; font-weight: 700; line-height: 1.25;
+      font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+      font-variant-numeric: tabular-nums;
+    }
+    .readout .l { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
+    .fps-good { color: var(--ok); }
+    .fps-mid { color: var(--warn); }
+    .fps-bad { color: var(--bad); }
+    .moves-low { color: var(--ok); }
+
+    #board {
+      position: relative;
+      border-radius: 12px;
+      touch-action: none;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+    #board .tile {
+      position: absolute;
+      top: 0; left: 0;
+      width: var(--tile, 30px);
+      height: var(--tile, 30px);
+      border-radius: 6px;
+      background: hsl(var(--h, 220) 72% 58%);
+      box-shadow: inset 0 -2px 0 rgb(0 0 0 / 0.22);
+      transition: transform 420ms cubic-bezier(0.22, 1, 0.36, 1), opacity 300ms ease-out;
+      cursor: grab;
+      will-change: transform;
+    }
+    #board .tile.dragging {
+      transition: none;
+      z-index: 10;
+      cursor: grabbing;
+      box-shadow: 0 10px 28px rgb(0 0 0 / 0.55);
+    }
+
+    footer { margin-top: 14px; color: var(--muted); font-size: 13px; }
+    footer a { color: var(--accent); }
+  </style>
+</head>
+<body>
+  <header>
+    <h1><code>repeat()</code> playground</h1>
+    <span class="hint">drag any tile — everything else stays put</span>
+  </header>
+
+  <div class="bar">
+    <button id="shuffle">Shuffle</button>
+    <button id="sort">Sort</button>
+    <button id="reverse">Reverse</button>
+    <button id="add">+24</button>
+    <button id="remove">−24</button>
+    <button id="storm">Storm</button>
+    <div class="spacer"></div>
+    <label class="count-control">
+      tiles
+      <input id="count" type="range" min="100" max="2400" step="100" value="800" />
+      <output data-bind="count"></output>
+    </label>
+  </div>
+
+  <div class="readouts">
+    <div class="readout"><div class="v" id="moves" data-bind="moves">—</div><div class="l">DOM moves, last update</div></div>
+    <div class="readout"><div class="v" data-bind="ms">—</div><div class="l">update ms</div></div>
+    <div class="readout"><div class="v" id="fps" data-bind="fps">—</div><div class="l">fps</div></div>
+  </div>
+
+  <div id="board"></div>
+
+  <footer>
+    One drag across the whole grid is <strong>1</strong> DOM move — <a href="../../docs/api/addons/repeat.md">repeat()</a> keeps every tile that's already in order and moves only what isn't.
+  </footer>
+
+  <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/examples/repeat-playground/main.js
+++ b/examples/repeat-playground/main.js
@@ -1,0 +1,245 @@
+import { state, bindDom } from 'lume-js';
+import { repeat } from 'lume-js/addons';
+
+// A grid of colored tiles you can reorder by hand. repeat() keys tiles by id
+// and moves only the DOM nodes that are out of place; the readouts count the
+// real insertBefore/removeChild calls so every claim on screen is measured.
+
+const board = document.getElementById('board');
+const countSlider = document.getElementById('count');
+
+let nextId = 1;
+const makeTile = () => ({ id: nextId++, hue: Math.floor(Math.random() * 360) });
+
+const store = state({
+  tiles: Array.from({ length: Number(countSlider.value) }, makeTile),
+});
+
+const ui = state({ moves: '—', ms: '—', fps: '—', count: String(store.tiles.length) });
+bindDom(document.body, ui);
+
+// ── Count real DOM operations on the board ─────────────────────────────────
+// reconcile calls insertBefore/removeChild on the container, so wrapping the
+// board's own methods counts exactly the reorder work — nothing else.
+let domOps = 0;
+for (const method of ['insertBefore', 'removeChild']) {
+  const original = board[method].bind(board);
+  board[method] = (...args) => { domOps++; return original(...args); };
+}
+
+// ── Tiles are placed by transform: reorders never trigger grid relayout ────
+const GAP = 4;
+const MIN_TILE = 26;
+const metrics = { cols: 1, step: 30, tile: 26 };
+
+function computeMetrics() {
+  const width = board.clientWidth;
+  const cols = Math.max(1, Math.floor((width + GAP) / (MIN_TILE + GAP)));
+  metrics.cols = cols;
+  metrics.tile = (width - (cols - 1) * GAP) / cols;
+  metrics.step = metrics.tile + GAP;
+  board.style.setProperty('--tile', metrics.tile + 'px');
+}
+
+function translateOf(index) {
+  const x = (index % metrics.cols) * metrics.step;
+  const y = Math.floor(index / metrics.cols) * metrics.step;
+  return `translate(${x}px, ${y}px)`;
+}
+
+function layout() {
+  const n = store.tiles.length;
+  board.style.height = Math.ceil(n / metrics.cols) * metrics.step - GAP + 'px';
+  let index = 0;
+  for (const el of board.children) {
+    if (el !== draggedEl) el.style.transform = translateOf(index);
+    el.style.opacity = '1';
+    index++;
+  }
+}
+
+computeMetrics();
+
+repeat('#board', store, 'tiles', {
+  key: (tile) => tile.id,
+  create: (tile, el, index) => {
+    el.className = 'tile';
+    el.style.setProperty('--h', tile.hue);
+    // Born in place, invisible: layout() fades it in without a fly-in.
+    el.style.transform = translateOf(index);
+    el.style.opacity = '0';
+  },
+});
+
+// ── Every mutation goes through commit(): measure, reconcile, reposition ───
+async function commit(nextTiles) {
+  domOps = 0;
+  const t0 = performance.now();
+  store.tiles = nextTiles;
+  await Promise.resolve(); // resumes after the flush microtask has reconciled
+  ui.ms = (performance.now() - t0).toFixed(1);
+  ui.moves = domOps.toLocaleString('en-US');
+  ui.count = store.tiles.length.toLocaleString('en-US');
+  layout();
+}
+
+commit(store.tiles);
+
+window.addEventListener('resize', () => {
+  computeMetrics();
+  layout();
+});
+
+// ── Drag to reorder: the array follows the pointer, tiles glide aside ──────
+let draggedEl = null;
+let draggedId = null;
+let grabDX = 0;
+let grabDY = 0;
+let lastTarget = -1;
+let reorderQueued = false;
+
+function pointerIndex(event) {
+  const rect = board.getBoundingClientRect();
+  const col = Math.min(metrics.cols - 1, Math.max(0, Math.floor((event.clientX - rect.left) / metrics.step)));
+  const row = Math.max(0, Math.floor((event.clientY - rect.top) / metrics.step));
+  return Math.min(store.tiles.length - 1, row * metrics.cols + col);
+}
+
+board.addEventListener('pointerdown', (event) => {
+  const el = event.target.closest('.tile');
+  if (!el) return;
+  const rect = el.getBoundingClientRect();
+  draggedEl = el;
+  // DOM order always matches array order, so the child index is the tile.
+  draggedId = store.tiles[Array.prototype.indexOf.call(board.children, el)].id;
+  // Grab by the point under the finger, not the tile corner.
+  grabDX = event.clientX - rect.left;
+  grabDY = event.clientY - rect.top;
+  lastTarget = pointerIndex(event);
+  el.classList.add('dragging');
+  el.setPointerCapture(event.pointerId);
+});
+
+board.addEventListener('pointermove', (event) => {
+  if (!draggedEl) return;
+  const rect = board.getBoundingClientRect();
+  const x = event.clientX - rect.left - grabDX;
+  const y = event.clientY - rect.top - grabDY;
+  draggedEl.style.transform = `translate(${x}px, ${y}px) scale(1.12)`;
+
+  const target = pointerIndex(event);
+  if (target === lastTarget || reorderQueued) return;
+  lastTarget = target;
+  reorderQueued = true;
+  requestAnimationFrame(() => {
+    reorderQueued = false;
+    const tiles = store.tiles;
+    const from = tiles.findIndex((tile) => tile.id === draggedId);
+    if (from === -1 || from === target) return;
+    const next = [...tiles];
+    const [moved] = next.splice(from, 1);
+    next.splice(target, 0, moved);
+    commit(next);
+  });
+});
+
+function endDrag() {
+  if (!draggedEl) return;
+  const el = draggedEl;
+  draggedEl = null;
+  draggedId = null;
+  el.classList.remove('dragging');
+  layout(); // snap into the slot it was dropped on
+}
+
+board.addEventListener('pointerup', endDrag);
+board.addEventListener('pointercancel', endDrag);
+
+// ── Controls ────────────────────────────────────────────────────────────────
+function shuffled(tiles) {
+  const next = [...tiles];
+  for (let i = next.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [next[i], next[j]] = [next[j], next[i]];
+  }
+  return next;
+}
+
+document.getElementById('shuffle').addEventListener('click', () => {
+  commit(shuffled(store.tiles));
+});
+
+document.getElementById('sort').addEventListener('click', () => {
+  commit([...store.tiles].sort((a, b) => a.hue - b.hue));
+});
+
+document.getElementById('reverse').addEventListener('click', () => {
+  commit([...store.tiles].reverse());
+});
+
+document.getElementById('add').addEventListener('click', () => {
+  const next = [...store.tiles];
+  for (let i = 0; i < 24; i++) {
+    next.splice(Math.floor(Math.random() * (next.length + 1)), 0, makeTile());
+  }
+  commit(next);
+});
+
+document.getElementById('remove').addEventListener('click', () => {
+  const next = [...store.tiles];
+  for (let i = 0; i < 24 && next.length > 1; i++) {
+    next.splice(Math.floor(Math.random() * next.length), 1);
+  }
+  commit(next);
+});
+
+countSlider.addEventListener('change', () => {
+  const target = Number(countSlider.value);
+  const next = [...store.tiles];
+  while (next.length < target) next.push(makeTile());
+  next.length = Math.min(next.length, target);
+  commit(next);
+});
+
+// ── Storm: a rolling wave of random far swaps, self-paced by commit() ──────
+const stormBtn = document.getElementById('storm');
+let stormOn = false;
+
+async function stormLoop() {
+  while (stormOn) {
+    const tiles = [...store.tiles];
+    const swaps = Math.max(4, Math.round(tiles.length / 12));
+    for (let i = 0; i < swaps; i++) {
+      const a = Math.floor(Math.random() * tiles.length);
+      const b = Math.floor(Math.random() * tiles.length);
+      [tiles[a], tiles[b]] = [tiles[b], tiles[a]];
+    }
+    await commit(tiles);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+  }
+}
+
+stormBtn.addEventListener('click', () => {
+  stormOn = !stormOn;
+  stormBtn.classList.toggle('storm-on', stormOn);
+  stormBtn.textContent = stormOn ? 'Stop' : 'Storm';
+  if (stormOn) stormLoop();
+});
+
+// ── FPS meter ───────────────────────────────────────────────────────────────
+const fpsEl = document.getElementById('fps');
+let frames = 0;
+let windowStart = performance.now();
+
+function meter(now) {
+  frames++;
+  if (now - windowStart >= 1000) {
+    const fps = Math.round((frames * 1000) / (now - windowStart));
+    ui.fps = String(fps);
+    fpsEl.className = 'v ' + (fps >= 45 ? 'fps-good' : fps >= 20 ? 'fps-mid' : 'fps-bad');
+    frames = 0;
+    windowStart = now;
+  }
+  requestAnimationFrame(meter);
+}
+requestAnimationFrame(meter);


### PR DESCRIPTION
## Summary

A visitor-facing showcase for the new minimal-move reconciler: a grid of up to 2,400 colored tiles you reorder **by hand**. Drag any tile anywhere — the array follows the pointer, every other tile glides aside by transform, and a live counter shows what the update really cost in DOM operations: one drag across the whole grid is **1 move**. Shuffle / sort-by-hue / reverse / scattered ±24 / storm cover the other reorder shapes. Deliberately minimal copy — one hint line and one footer sentence; the readouts do the explaining. This replaces `repeat-test` as the linked repeat() example (that page is a scripted assertion suite, already covered by `tests/addons/repeat.test.js` — the folder stays, the card is removed).

## Type of change

- [x] `feat` — new feature or API addition (example only — no library code)
- [x] `fix` — bug fix (pre-existing broken card on the examples index, see below)
- [ ] `perf` — performance improvement (no API change)
- [ ] `refactor` — code restructuring (no behavior change)
- [ ] `docs` — documentation only
- [ ] `test` — test addition or fix
- [ ] `chore` / `ci` / `build` — tooling, CI, build changes

## Changes

- `examples/repeat-playground/` (new) — dark, dense tile grid. Tiles are absolutely positioned by index math and placed with `transform`, so reorders never trigger grid relayout; new tiles are born in place and fade in. Pointer-events drag (works on touch), live array reorder throttled to animation frames. The DOM-move counter wraps the board element's own `insertBefore`/`removeChild` — exactly the calls `repeat()`'s reconciler makes — so every number on screen is measured, not claimed.
- `examples/index.html` — new card (NEW badge); `repeat-test` card removed (folder untouched).
- `fix(examples)` commit: the Template Lists card's description contained a literal `<template>` string that the index's `innerHTML` renderer parsed as a real inert template element, swallowing the card's View Demo link — pre-existing on main, escaped now; all 10 cards render with working links (Chromium-verified).

## Measured in Chromium (real browser, this branch)

| action | DOM moves readout |
|---|---|
| drag one tile across the full grid | **1** |
| remove 24 scattered tiles | 24 removals, **0 moves** |
| add 24 scattered tiles | 24 |
| shuffle 800 tiles | ~750 (honest worst case) |
| storm tick (67 swaps of 776) | ~117 |

2,400 tiles at 50 fps headless; zero console errors.

## Test plan

- [ ] Added tests covering the new behavior — examples aren't unit-tested by design; the reconciler behavior shown here is asserted by the 7 move-count tests in `tests/addons/repeat.test.js`
- [x] Ran `npm run coverage` — 100% coverage maintained (468 tests)
- [x] Manual verification: full `npm run validate` green; driven end-to-end in Chromium via Playwright — every control clicked, synthetic drag performed, readouts asserted (numbers above), examples index cards verified

## Bundle size impact

No bundle impact — examples only, `src/` untouched (state 1.46 KB gz / index 2.73 / addons 4.96, unchanged).

## Breaking changes

None.

---

## Pre-merge checklist

- [x] `npm run coverage` passes — 100% statements, branches, functions, lines
- [x] `npm run typecheck` passes — zero TypeScript errors
- [x] `npm run lint` passes — cognitive complexity ≤ 15 per function
- [x] `node scripts/complexity.js` passes — max CC ≤ 10, MI ≥ 50
- [x] `npm run size` within budget — core ≤ 3 KB, addons ≤ 6 KB, handlers ≤ 2 KB
- [x] Commit messages follow Conventional Commits (`type(scope): subject`)
- [x] Docs updated if API changed (no API change)
- [x] `src/index.d.ts` updated if public API changed (no API change)