### PR TITLE
chore(release): prepare v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-07-20
+
 ### Changed
 
 - **Writes to an unobserved store now skip the flush pipeline entirely:** when a store has no subscribers on any key and no `$beforeFlush` hooks, the `set` trap stores the value and returns — no pending-notification bookkeeping, no batch enqueue, no microtask flush. High-churn stores read back by polling (e.g. a render loop) get reactive writes within ~1–2x of plain-object writes: in a 3,000-cell stress grid under a 20x CPU throttle, the worst write-pass frame dropped from 156ms to 16ms (~10x) and the kernel's share of active CPU fell from ~9% to ~1.5%. Observed stores are unchanged, and a later `$subscribe` still sees the current value immediately. One subtle sharpening: a subscriber registered between a write and its microtask no longer receives a duplicate delivery of that write on the flush — the immediate `$subscribe` call already handed it the current value. Kernel cost: +0.03 KB gz (1.46 → 1.49, budget 1.75).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
     &nbsp;
 <!-- lume:badge-version -->
-    <a href="package.json"><img src="https://img.shields.io/badge/version-2.3.1-orange.svg" alt="v2.3.1"></a>
+    <a href="package.json"><img src="https://img.shields.io/badge/version-2.4.0-orange.svg" alt="v2.4.0"></a>
 <!-- /lume:badge-version -->
     &nbsp;
 <!-- lume:badge-tests -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 **Lume.js** is a lightweight reactive state library built on standard JavaScript and HTML. Drop it into any page via a CDN `<script>` tag and get reactive bindings in minutes — no build tool, no custom syntax, no framework required.
 
-> **Version:** <!-- lume:version -->2.3.1<!-- /lume:version --> · **Core:** <!-- lume:size-state -->1.49<!-- /lume:size-state --> KB gzipped (universal) / <!-- lume:size-index -->2.77<!-- /lume:size-index --> KB gzipped (+ DOM) · **Tests:** <!-- lume:tests -->475<!-- /lume:tests --> · **Dependencies:** 0
+> **Version:** <!-- lume:version -->2.4.0<!-- /lume:version --> · **Core:** <!-- lume:size-state -->1.49<!-- /lume:size-state --> KB gzipped (universal) / <!-- lume:size-index -->2.77<!-- /lume:size-index --> KB gzipped (+ DOM) · **Tests:** <!-- lume:tests -->475<!-- /lume:tests --> · **Dependencies:** 0
 
 ## Why Lume.js?
 

--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -2,7 +2,7 @@
 
 ## Is Lume.js production-ready?
 
-Yes. Lume 2.x is stable — the current release on npm is v<!-- lume:version -->2.3.1<!-- /lume:version --> (`npm install lume-js`), backed by <!-- lume:tests -->475<!-- /lume:tests --> tests at 100% coverage and CI-enforced size budgets. The core API (`state`, `bindDom`, `effect`, `batch`) and all addons (`watch`, `computed`, `repeat`, `persist`, `withPlugins`, …) are stable. The 1.x series is legacy — see [Migrating from 1.x](migration.md).
+Yes. Lume 2.x is stable — the current release on npm is v<!-- lume:version -->2.4.0<!-- /lume:version --> (`npm install lume-js`), backed by <!-- lume:tests -->475<!-- /lume:tests --> tests at 100% coverage and CI-enforced size budgets. The core API (`state`, `bindDom`, `effect`, `batch`) and all addons (`watch`, `computed`, `repeat`, `persist`, `withPlugins`, …) are stable. The 1.x series is legacy — see [Migrating from 1.x](migration.md).
 
 ## Does Lume work without a build step?
 

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -19,7 +19,7 @@ For production, pin to an exact version so your page can't break on a new releas
 ```html
 <!-- exact version (recommended for production) -->
 <!-- lume:pin-url -->
-'https://cdn.jsdelivr.net/npm/lume-js@2.3.1/dist/index.min.mjs'
+'https://cdn.jsdelivr.net/npm/lume-js@2.4.0/dist/index.min.mjs'
 <!-- /lume:pin-url -->
 
 <!-- latest stable -->

--- a/docs/metrics.json
+++ b/docs/metrics.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1",
+  "version": "2.4.0",
   "tests": 475,
   "sizes": {
     "state": "1.49",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,7 +8,7 @@
 > microtask-batched per store with an explicit batch() escape hatch for
 > cross-store writes.
 
-Version: 2.3.1. Install: `npm install lume-js` or import from
+Version: 2.4.0. Install: `npm install lume-js` or import from
 `https://cdn.jsdelivr.net/npm/lume-js/dist/index.min.mjs`.
 
 Key facts agents get wrong without reading the docs: arrays and nested
@@ -267,7 +267,7 @@ FILE: README.md
   <p>
     <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
     &nbsp;
-<a href="package.json"><img src="https://img.shields.io/badge/version-2.3.1-orange.svg" alt="v2.3.1"></a>
+<a href="package.json"><img src="https://img.shields.io/badge/version-2.4.0-orange.svg" alt="v2.4.0"></a>
     &nbsp;
 <a href="tests/"><img src="https://img.shields.io/badge/tests-475%20passing-brightgreen.svg" alt="475 tests"></a>
     &nbsp;
@@ -623,7 +623,7 @@ For production, pin to an exact version so your page can't break on a new releas
 
 ```html
 <!-- exact version (recommended for production) -->
-'https://cdn.jsdelivr.net/npm/lume-js@2.3.1/dist/index.min.mjs'
+'https://cdn.jsdelivr.net/npm/lume-js@2.4.0/dist/index.min.mjs'
 
 <!-- latest stable -->
 'https://cdn.jsdelivr.net/npm/lume-js/dist/index.min.mjs'
@@ -6888,7 +6888,7 @@ FILE: docs/guides/faq.md
 
 ## Is Lume.js production-ready?
 
-Yes. Lume 2.x is stable — the current release on npm is v2.3.1 (`npm install lume-js`), backed by 475 tests at 100% coverage and CI-enforced size budgets. The core API (`state`, `bindDom`, `effect`, `batch`) and all addons (`watch`, `computed`, `repeat`, `persist`, `withPlugins`, …) are stable. The 1.x series is legacy — see [Migrating from 1.x](migration.md).
+Yes. Lume 2.x is stable — the current release on npm is v2.4.0 (`npm install lume-js`), backed by 475 tests at 100% coverage and CI-enforced size budgets. The core API (`state`, `bindDom`, `effect`, `batch`) and all addons (`watch`, `computed`, `repeat`, `persist`, `withPlugins`, …) are stable. The 1.x series is legacy — see [Migrating from 1.x](migration.md).
 
 ## Does Lume work without a build step?
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 > microtask-batched per store with an explicit batch() escape hatch for
 > cross-store writes.
 
-Version: 2.3.1. Install: `npm install lume-js` or import from
+Version: 2.4.0. Install: `npm install lume-js` or import from
 `https://cdn.jsdelivr.net/npm/lume-js/dist/index.min.mjs`.
 
 Key facts agents get wrong without reading the docs: arrays and nested

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lume-js",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "Minimal reactive state management using only standard JavaScript and HTML - no custom syntax, no build step required",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary

Prepares v2.4.0 for release: version bump, CHANGELOG cutover from `[Unreleased]` to a dated `[2.4.0]` section, and regenerated docs (README, docs/README, faq, installation, metrics.json, llms bundles) via `npm run docs:sync`. All three changes below were already merged to `main` in prior commits — this PR only does the release bookkeeping.

Scoped narrower than the original `docs/changes/18` roadmap plan, which also listed a `renderQueue` addon: an unmerged research branch (14 rounds) delivered a KILL verdict on `renderQueue` as designed (freezes under sustained load, starves under the common re-dirty order, beaten by free CSS `content-visibility`), so it and its demo examples are excluded from this release.

## Type of change

- [ ] `feat` — new feature or API addition
- [ ] `fix` — bug fix
- [x] `perf` — performance improvement (no API change)
- [ ] `refactor` — code restructuring (no behavior change)
- [ ] `docs` — documentation only
- [ ] `test` — test addition or fix
- [x] `chore` / `ci` / `build` — tooling, CI, build changes

## Changes

- Kernel: writes to a store with no subscribers and no `$beforeFlush` hooks skip the flush pipeline entirely (worst write-pass frame 156ms → 16ms at 20x throttle on a 3,000-cell stress grid)
- `effect()`: re-runs reuse dependency subscriptions across runs instead of tearing down and rebuilding them (3,000-store effect re-run 23.8ms → 3.2ms, 7.5x)
- `repeat()`: reorders now compute a minimal-move plan (LIS over previous positions) instead of a forward pass that cascades into every node after the first mismatch (2,000-tile storm: ~2,000 → ~310 DOM moves/tick)
- `package.json` version 2.3.1 → 2.4.0; `CHANGELOG.md` `[Unreleased]` → `[2.4.0] - 2026-07-20`
- Regenerated managed docs via `npm run docs:sync`

## Test plan

- [x] Added tests covering the new behavior
- [x] Ran `npm run coverage` — 100% coverage maintained
- [x] Manual verification: `npm run validate` green end-to-end on this branch (build, size budgets, complexity, lint, typecheck, coverage, docs:check) — 475 tests passing

## Bundle size impact

```
state.min.mjs    3.46 KB  → 1.49 KB gz  (budget 1.75 KB)
index.min.mjs    6.92 KB  → 2.77 KB gz
addons.min.mjs  13.75 KB  → 4.96 KB gz  (budget 6 KB)
handlers.min.mjs 2.61 KB  → 1.23 KB gz  (budget 2 KB)
```
Kernel cost from the no-subscriber fast-path: +0.03 KB gz (1.46 → 1.49). All entries within budget.

## Breaking changes

None. One subtle behavioral sharpening: a `$subscribe` registered between a write and its microtask no longer receives a duplicate delivery of that write on flush (documented in the CHANGELOG entry).

---

## Pre-merge checklist

- [x] `npm run coverage` passes — 100% statements, branches, functions, lines
- [x] `npm run typecheck` passes — zero TypeScript errors
- [x] `npm run lint` passes — cognitive complexity ≤ 15 per function
- [x] `node scripts/complexity.js` passes — max CC ≤ 10, MI ≥ 50
- [x] `npm run size` within budget — core ≤ 3 KB, addons ≤ 6 KB, handlers ≤ 2 KB
- [x] Commit messages follow Conventional Commits (`type(scope): subject`)
- [x] Docs updated if API changed (`docs/api/`, `README.md`, `CONTRIBUTING.md`)
- [ ] `src/index.d.ts` updated if public API changed — N/A, no public API changed in this PR
